### PR TITLE
[MEDI-27] Add personal YAML file 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.0'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'com.google.cloud.tools.jib' version '3.4.0'
 }
 
 group = 'com'
@@ -19,8 +20,23 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	// Spring Jpa
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	//Swagger
+//	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
+	// Lombok
+	implementation 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+	compileOnly 'org.projectlombok:lombok'
+	//DatabaseCleanUp
+	implementation group: 'com.google.guava', name: 'guava', version: '12.0'
+	// mysql
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'com.h2database:h2'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/my_medi/api/user/controller/UserApiController.java
+++ b/src/main/java/com/my_medi/api/user/controller/UserApiController.java
@@ -1,0 +1,29 @@
+package com.my_medi.api.user.controller;
+
+import com.my_medi.domain.user.entity.User;
+import com.my_medi.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserApiController {
+
+    //지금은 테스트를 위해 레포지토리 의존성 주입을 해둔 상태입니다
+    private final UserRepository userRepository;
+
+    //TODO remove this method
+    @Transactional
+    @PostMapping
+    public Long registerUserForTest() {
+        return userRepository.save(
+                User
+                .builder()
+                .userUuid("test")
+                .build()).getId();
+    }
+}

--- a/src/main/java/com/my_medi/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/my_medi/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.my_medi.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/my_medi/common/consts/StaticVariable.java
+++ b/src/main/java/com/my_medi/common/consts/StaticVariable.java
@@ -1,0 +1,4 @@
+package com.my_medi.common.consts;
+
+public class StaticVariable {
+}

--- a/src/main/java/com/my_medi/domain/enums/AlarmType.java
+++ b/src/main/java/com/my_medi/domain/enums/AlarmType.java
@@ -1,0 +1,5 @@
+package com.my_medi.domain.enums;
+
+public enum AlarmType {
+    CONSULTATION, SCHEDULE
+}

--- a/src/main/java/com/my_medi/domain/enums/ExpertJob.java
+++ b/src/main/java/com/my_medi/domain/enums/ExpertJob.java
@@ -1,0 +1,5 @@
+package com.my_medi.domain.enums;
+
+public enum ExpertJob {
+    DIETITIAN, HEALTHMANAGER, WELLNESSCOACH, EXERCISETHERAPIST
+}

--- a/src/main/java/com/my_medi/domain/enums/GenderState.java
+++ b/src/main/java/com/my_medi/domain/enums/GenderState.java
@@ -1,0 +1,5 @@
+package com.my_medi.domain.enums;
+
+public enum GenderState {
+    MALE, FEMALE, OTHER
+}

--- a/src/main/java/com/my_medi/domain/expert/entity/Expert.java
+++ b/src/main/java/com/my_medi/domain/expert/entity/Expert.java
@@ -1,0 +1,21 @@
+package com.my_medi.domain.expert.entity;
+
+import com.my_medi.domain.member.entity.Member;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@DiscriminatorValue("type_expert")      //TODO ROLE ENUM key값으로
+public class Expert extends Member {
+
+    private String expertUuid;
+}

--- a/src/main/java/com/my_medi/domain/expertAlarm/entity/ExpertAlarm.java
+++ b/src/main/java/com/my_medi/domain/expertAlarm/entity/ExpertAlarm.java
@@ -1,0 +1,55 @@
+package com.my_medi.domain.expertAlarm.entity;
+
+import com.my_medi.domain.enums.AlarmType;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ExpertAlarm {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long expertAlarmId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "expert_id", nullable = false)
+    private Long expertId;
+
+    // 상담? 진찰? 날짜
+    @Column(name = "consultation_date", nullable = false)
+    private LocalDate consultationDate;
+
+    // 시작 시간
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    // 종료 시간
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    // 알림 제목
+    @Column(name = "alarm_title", nullable = false, length = 50)
+    private String alarmTitle;
+
+    // 알림 내용
+    @Column(name = "alarm_contents", nullable = false, length = 50)
+    private String alarmContents;
+
+    // 장소
+    @Column(name = "alarm_location", nullable = false, length = 50)
+    private String alarmLocation;
+
+    // 알림 종류 - 전문가는 CONSULTATION 고정?
+    @Enumerated(EnumType.STRING)
+    @Column(name = "alarm_type", nullable = false)
+    private AlarmType alarmType;
+}

--- a/src/main/java/com/my_medi/domain/member/entity/Member.java
+++ b/src/main/java/com/my_medi/domain/member/entity/Member.java
@@ -1,0 +1,20 @@
+package com.my_medi.domain.member.entity;
+
+import com.my_medi.domain.model.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Inheritance(strategy = InheritanceType.JOINED)
+public abstract class Member extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+}

--- a/src/main/java/com/my_medi/domain/model/entity/BaseTimeEntity.java
+++ b/src/main/java/com/my_medi/domain/model/entity/BaseTimeEntity.java
@@ -1,0 +1,31 @@
+package com.my_medi.domain.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@MappedSuperclass
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}

--- a/src/main/java/com/my_medi/domain/proposal/entity/Proposal.java
+++ b/src/main/java/com/my_medi/domain/proposal/entity/Proposal.java
@@ -1,0 +1,53 @@
+package com.my_medi.domain.proposal.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Proposal {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long proposalId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    // 1. 직업 및 생활패턴
+    @Column(name = "life_descreption", nullable = false, length = 50)
+    private String lifeDescreption;
+
+    // 2. 건강 관심 분야(중복 선택 가능)
+    private Boolean weightManagement;
+    private Boolean bloodSugarControl;
+    private Boolean cholesterolControl;
+    private Boolean bloodPressureControl;
+    private Boolean liverFunctionCare;
+    private Boolean sleepRecovery;
+    private Boolean dietImprovement;
+    private Boolean exerciseRoutine;
+    private Boolean stressAndLifestyle;
+
+    // 3. 최근 건강검진 결과 이상 수치가 있었던 항목이 있다면 선택해주세요.
+    private Boolean fastingBloodSugar;
+    private Boolean cholesterolLdl;
+    private Boolean bloodPressure;
+    private Boolean liverEnzymes;
+    private Boolean bmiOrBodyFat;
+    private Boolean noHealthCheckResult;
+
+    // 4. 어떤 전문가의 도움을 받고 싶으신가요?
+    private Boolean dietitian;
+    private Boolean healthManager;
+    private Boolean wellnessCoach;
+    private Boolean exerciseTherapist;
+    private Boolean recommendForMe;
+
+    // 5. 목표나 기대하는 변화가 있다면 적어주세요.
+    @Column(name = "goal", nullable = false, length = 50)
+    private String goal;
+}

--- a/src/main/java/com/my_medi/domain/resume/entity/Resume.java
+++ b/src/main/java/com/my_medi/domain/resume/entity/Resume.java
@@ -1,0 +1,51 @@
+package com.my_medi.domain.resume.entity;
+
+import com.my_medi.domain.enums.ExpertJob;
+import com.my_medi.domain.enums.GenderState;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Resume {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long resumeId;
+
+    @Column(name = "expert_id", nullable = false)
+    private Long expertId;
+
+    // 전문가 이름, 나이, 성별, 프로필 사진
+    @Column(name = "name", nullable = false, length = 10)
+    private String name;
+    @Column(name = "age", nullable = false)
+    private Integer age;
+    @Enumerated(EnumType.STRING)
+    private GenderState gender;
+    @Lob
+    @Column(columnDefinition = "LONGBLOB") // MySQL 기준
+    private byte[] imageData;
+
+    // 전문가 직업
+    private ExpertJob expertJob;
+    // 자격증, PDF...등등
+    @Column(name = "file_path", nullable = false, length = 50)
+    private String filePath;
+    // 경력
+    @Column(name = "company", nullable = false, length = 20)
+    private String company;
+    @Column(name = "company_role", nullable = false, length = 20)
+    private String companyRole;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    @Column(name = "description", nullable = false, length = 100)
+    private String description;
+}

--- a/src/main/java/com/my_medi/domain/user/entity/User.java
+++ b/src/main/java/com/my_medi/domain/user/entity/User.java
@@ -1,0 +1,21 @@
+package com.my_medi.domain.user.entity;
+
+import com.my_medi.domain.member.entity.Member;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@DiscriminatorValue("type_user")      //TODO ROLE ENUM key값으로
+public class User extends Member {
+
+    private String userUuid;
+}

--- a/src/main/java/com/my_medi/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/my_medi/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.my_medi.domain.user.repository;
+
+import com.my_medi.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User,Long> {
+}

--- a/src/main/java/com/my_medi/domain/userAlarm/entity/UserAlarm.java
+++ b/src/main/java/com/my_medi/domain/userAlarm/entity/UserAlarm.java
@@ -1,0 +1,58 @@
+package com.my_medi.domain.userAlarm.entity;
+
+import com.my_medi.domain.enums.AlarmType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserAlarm {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userAlarmId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "expert_id", nullable = false)
+    private Long expertId;
+
+    // 예약 날짜
+    @Column(name = "reservation_date", nullable = false)
+    private LocalDate reservationDate;
+
+    // 시작 시간
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    // 종료 시간
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    // 알림 제목
+    @Column(name = "alarm_title", nullable = false, length = 50)
+    private String alarmTitle;
+
+    // 알림 내용
+    @Column(name = "alarm_contents", nullable = false, length = 50)
+    private String alarmContents;
+
+    // 장소
+    @Column(name = "alarm_location", nullable = false, length = 50)
+    private String alarmLocation;
+
+    // 알림 종류
+    @Enumerated(EnumType.STRING)
+    @Column(name = "alarm_type", nullable = false)
+    private AlarmType alarmType;
+}

--- a/src/main/resources/application-go.yml
+++ b/src/main/resources/application-go.yml
@@ -1,0 +1,13 @@
+spring:
+  config:
+    activate:
+      on-profile: go
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/medi?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+    username: root
+    password: MySQLpass1157!!
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update

--- a/src/main/resources/application-go.yml
+++ b/src/main/resources/application-go.yml
@@ -6,7 +6,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/medi?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
     username: root
-    password: MySQLpass1157!!
+    password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=my-medi

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+spring:
+  profiles:
+    active:
+      - ${ACTIVE_PROFILE}


### PR DESCRIPTION
## #️⃣ 요약 설명

## 📝 작업 내용

> ex) 코드의 흐름이나 중요한 부분을 작성해주세요.
> ex) 기존 calculate 함수의 버그를 수정했습니다.

```java
중요한 코드 부분을 붙여넣어 설명해주세요.
```

## 동작 확인

### API 확인 
![화면 캡처 2025-07-04 112625](https://github.com/user-attachments/assets/377ff96a-e56a-46dd-9a18-9578f947345e)

### medi DB 확인
![화면 캡처 2025-07-04 112750](https://github.com/user-attachments/assets/e99268a0-24d5-4407-9f63-a75fa485dea9)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * JPA 엔티티 및 상속 구조(회원, 전문가, 사용자) 도입
  * 사용자 등록을 위한 테스트용 REST API 추가
  * 사용자 데이터 저장 및 조회를 위한 JPA 리포지토리 추가
  * JPA 감사(Auditing) 기능 활성화 및 관련 기본 엔티티 도입

* **설정**
  * MySQL 및 H2 데이터베이스 연동 설정 파일 추가
  * Lombok, JPA, Guava 등 주요 라이브러리 및 Jib 플러그인 의존성 추가
  * Spring 프로필을 환경 변수로 동적으로 설정 가능

* **기타**
  * 향후 활용을 위한 빈 클래스(StaticVariable) 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->