### PR TITLE
[Medi 29] ERD design (Member/User/Expert)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	// Spring Jpa
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/my_medi/common/consts/StaticVariable.java
+++ b/src/main/java/com/my_medi/common/consts/StaticVariable.java
@@ -1,4 +1,6 @@
 package com.my_medi.common.consts;
 
 public class StaticVariable {
+    public static final String USER = "type_user";
+    public static final String EXPERT = "type_expert";
 }

--- a/src/main/java/com/my_medi/domain/Discriminator.java
+++ b/src/main/java/com/my_medi/domain/Discriminator.java
@@ -1,0 +1,8 @@
+package com.my_medi.domain;
+
+public class Discriminator {
+    public static final String USER = "type_user";
+    public static final String EXPERT = "type_expert";
+
+    private Discriminator() {} // 인스턴스 생성 방지
+}

--- a/src/main/java/com/my_medi/domain/Discriminator.java
+++ b/src/main/java/com/my_medi/domain/Discriminator.java
@@ -1,8 +1,0 @@
-package com.my_medi.domain;
-
-public class Discriminator {
-    public static final String USER = "type_user";
-    public static final String EXPERT = "type_expert";
-
-    private Discriminator() {} // 인스턴스 생성 방지
-}

--- a/src/main/java/com/my_medi/domain/expert/entity/Expert.java
+++ b/src/main/java/com/my_medi/domain/expert/entity/Expert.java
@@ -1,13 +1,14 @@
 package com.my_medi.domain.expert.entity;
 
 import com.my_medi.domain.member.entity.Member;
-import jakarta.persistence.DiscriminatorValue;
-import jakarta.persistence.Entity;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
 
 @Entity
 @Getter
@@ -18,4 +19,22 @@ import lombok.experimental.SuperBuilder;
 public class Expert extends Member {
 
     private String expertUuid;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id") // FK 컬럼명
+    private Member member_id;
+
+    @Column(name = "profile_img_url")
+    private String profileImgUrl;
+
+    @Column(name = "license_file_url")
+    private String licenseFileUrl;
+
+    //분야는 ExpertCategory의 enum으로 조회(ArrayList로 가져와야하는지 고민)
+
+    private String introduction;
+
+    // @OneToMany(mappedBy = "expert", cascade = CascadeType.ALL, orphanRemoval = true)
+    // private List<경력테이블> careers = new ArrayList<>();
+
 }

--- a/src/main/java/com/my_medi/domain/expert/entity/Expert.java
+++ b/src/main/java/com/my_medi/domain/expert/entity/Expert.java
@@ -20,10 +20,6 @@ public class Expert extends Member {
 
     private String expertUuid;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id") // FK 컬럼명
-    private Member member_id;
-
     private String licenseFileUrl;
 
     private String introduction;

--- a/src/main/java/com/my_medi/domain/expert/entity/Expert.java
+++ b/src/main/java/com/my_medi/domain/expert/entity/Expert.java
@@ -24,15 +24,11 @@ public class Expert extends Member {
     @JoinColumn(name = "member_id") // FK 컬럼명
     private Member member_id;
 
-    @Column(name = "profile_img_url")
-    private String profileImgUrl;
-
-    @Column(name = "license_file_url")
     private String licenseFileUrl;
 
-    //분야는 ExpertCategory의 enum으로 조회(ArrayList로 가져와야하는지 고민)
-
     private String introduction;
+
+    //분야는 ExpertCategory의 enum으로 조회(ArrayList로 가져와야하는지 고민)
 
     // @OneToMany(mappedBy = "expert", cascade = CascadeType.ALL, orphanRemoval = true)
     // private List<경력테이블> careers = new ArrayList<>();

--- a/src/main/java/com/my_medi/domain/expert/entity/Expert.java
+++ b/src/main/java/com/my_medi/domain/expert/entity/Expert.java
@@ -1,6 +1,8 @@
 package com.my_medi.domain.expert.entity;
 
+import com.my_medi.domain.Discriminator;
 import com.my_medi.domain.member.entity.Member;
+import com.my_medi.domain.member.entity.Role;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -15,18 +17,34 @@ import java.util.ArrayList;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@DiscriminatorValue("type_expert")      //TODO ROLE ENUM key값으로
+@DiscriminatorValue(Discriminator.EXPERT)      //TODO ROLE ENUM key값으로
 public class Expert extends Member {
 
+    @Column(unique = true)
     private String expertUuid;
 
+    //전문분야(enum)
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Specialty specialty;
+
+    //소속 회사 기관명
+    private String organizationName;
+
+    // 자격증
+    // 데이터베이스에 입력될 텍스트 크기를 길게 설정
+    @Column(length = 1000)
     private String licenseFileUrl;
 
-    private String introduction;
-
-    //분야는 ExpertCategory의 enum으로 조회(ArrayList로 가져와야하는지 고민)
-
+    // 경력사항(추후 연관관계로 받아올 예정)
     // @OneToMany(mappedBy = "expert", cascade = CascadeType.ALL, orphanRemoval = true)
     // private List<경력테이블> careers = new ArrayList<>();
+
+    //경력소개
+    // 데이터베이스에 입력될 텍스트 크기를 길게 설정
+    @Column(columnDefinition = "TEXT")
+    private String introduction;
+
+
 
 }

--- a/src/main/java/com/my_medi/domain/expert/entity/Expert.java
+++ b/src/main/java/com/my_medi/domain/expert/entity/Expert.java
@@ -1,6 +1,6 @@
 package com.my_medi.domain.expert.entity;
 
-import com.my_medi.domain.Discriminator;
+import com.my_medi.common.consts.StaticVariable;
 import com.my_medi.domain.member.entity.Member;
 import com.my_medi.domain.member.entity.Role;
 import jakarta.persistence.*;
@@ -17,7 +17,7 @@ import java.util.ArrayList;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@DiscriminatorValue(Discriminator.EXPERT)      //TODO ROLE ENUM key값으로
+@DiscriminatorValue(StaticVariable.EXPERT)      //TODO ROLE ENUM key값으로
 public class Expert extends Member {
 
     @Column(unique = true)

--- a/src/main/java/com/my_medi/domain/expert/entity/Specialty.java
+++ b/src/main/java/com/my_medi/domain/expert/entity/Specialty.java
@@ -1,0 +1,13 @@
+package com.my_medi.domain.expert.entity;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Specialty {
+    NUTRITIONIST,//영양사
+    HEALTH_MANAGER, // 건강관리사
+    WELLNESS_COACH, //웰니스코치
+    EXERCISE_THERAPIST, //운동처방사
+    ETC;//기타
+}

--- a/src/main/java/com/my_medi/domain/member/entity/Gender.java
+++ b/src/main/java/com/my_medi/domain/member/entity/Gender.java
@@ -1,0 +1,11 @@
+package com.my_medi.domain.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Gender {
+    MALE,   // 남자
+    FEMALE  // 여자
+}

--- a/src/main/java/com/my_medi/domain/member/entity/Member.java
+++ b/src/main/java/com/my_medi/domain/member/entity/Member.java
@@ -17,4 +17,24 @@ public abstract class Member extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
     private Long id;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    //마이페이지 내 닉네임(전문가, user 동일하므로 member에 삽입)
+    private String nickname;
+
+    //실제 이름
+    @Column(nullable = false)
+    private String name;
+
+    //회원가입
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+
 }

--- a/src/main/java/com/my_medi/domain/member/entity/Member.java
+++ b/src/main/java/com/my_medi/domain/member/entity/Member.java
@@ -7,6 +7,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.Size;
+
 @Entity
 @Getter
 @SuperBuilder
@@ -18,28 +22,47 @@ public abstract class Member extends BaseTimeEntity {
     @Column(name = "member_id")
     private Long id;
 
+    //역할(개인, 전문가 구분)
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    //마이페이지 내 닉네임(전문가, user 동일하므로 member에 삽입)
+    //성명
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    //생년월일
+    private LocalDate birthDate;
+
+    //성별 필드 추가 (남자, 여자)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender")
+    private Gender gender;
+
+    //닉네임
     @Column(unique = true, nullable = true) // 회원가입시 입력받지 않으므로 기본 null
     private String nickname;
 
-    //실제 이름
-    @Column(nullable = false)
-    private String last_name; // 성
+    //아이디(제약조건 : 8글자 이상)
+    @Column(name = "login_id", nullable = false, unique = true)
+    @Size(min = 8, message = "아이디는 최소 8자 이상이어야 합니다.")
+    private String loginId;
 
+    //비밀번호(제약조건 : 8글자 이상)
     @Column(nullable = false)
-    private String first_name;// 이름
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    private String password;
 
-    //회원가입
+    //이메일
+    // TODO: email, password : 검증 어노테이션, presentation(web 혹은 api) 레이어에 좀 더 적합하므로 추후 수정
     @Column(nullable = false)
     private String email;
 
-    @Column(nullable = false)
-    private String password;
+    //연락처
+    @Column(name = "phone_number", nullable = false)
+    private String phoneNumber;
 
+    //프로필 이미지
     @Column(nullable = true) // 회원가입시 입력받지 않으므로 기본 null
     private String profileImgUrl;
 

--- a/src/main/java/com/my_medi/domain/member/entity/Member.java
+++ b/src/main/java/com/my_medi/domain/member/entity/Member.java
@@ -23,11 +23,15 @@ public abstract class Member extends BaseTimeEntity {
     private Role role;
 
     //마이페이지 내 닉네임(전문가, user 동일하므로 member에 삽입)
+    @Column(unique = true, nullable = true) // 회원가입시 입력받지 않으므로 기본 null
     private String nickname;
 
     //실제 이름
     @Column(nullable = false)
-    private String name;
+    private String last_name; // 성
+
+    @Column(nullable = false)
+    private String first_name;// 이름
 
     //회원가입
     @Column(nullable = false)
@@ -35,6 +39,9 @@ public abstract class Member extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String password;
+
+    @Column(nullable = true) // 회원가입시 입력받지 않으므로 기본 null
+    private String profileImgUrl;
 
 
 }

--- a/src/main/java/com/my_medi/domain/member/entity/Member.java
+++ b/src/main/java/com/my_medi/domain/member/entity/Member.java
@@ -32,7 +32,7 @@ public abstract class Member extends BaseTimeEntity {
     private String name;
 
     //생년월일
-    @Column(name = "birth_date", nullable = false)
+    @Column(name = "birth_date")
     private LocalDate birthDate;
 
     //성별 필드 추가 (남자, 여자)

--- a/src/main/java/com/my_medi/domain/member/entity/Member.java
+++ b/src/main/java/com/my_medi/domain/member/entity/Member.java
@@ -23,7 +23,7 @@ public abstract class Member extends BaseTimeEntity {
     private Long id;
 
     //역할(개인, 전문가 구분)
-    @Column(nullable = false)
+    @Column(name = "role", nullable = false)
     @Enumerated(EnumType.STRING)
     private Role role;
 
@@ -32,15 +32,16 @@ public abstract class Member extends BaseTimeEntity {
     private String name;
 
     //생년월일
+    @Column(name = "birth_date", nullable = false)
     private LocalDate birthDate;
 
     //성별 필드 추가 (남자, 여자)
     @Enumerated(EnumType.STRING)
-    @Column(name = "gender")
+    @Column(name = "gender", nullable = false)
     private Gender gender;
 
     //닉네임
-    @Column(unique = true, nullable = true) // 회원가입시 입력받지 않으므로 기본 null
+    @Column(name = "nickname", unique = true, nullable = true) // 회원가입시 입력받지 않으므로 기본 null
     private String nickname;
 
     //아이디(제약조건 : 8글자 이상)
@@ -49,13 +50,13 @@ public abstract class Member extends BaseTimeEntity {
     private String loginId;
 
     //비밀번호(제약조건 : 8글자 이상)
-    @Column(nullable = false)
+    @Column(name = "password", nullable = false)
     @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
     private String password;
 
     //이메일
     // TODO: email, password : 검증 어노테이션, presentation(web 혹은 api) 레이어에 좀 더 적합하므로 추후 수정
-    @Column(nullable = false)
+    @Column(name = "email", nullable = false)
     private String email;
 
     //연락처
@@ -63,7 +64,7 @@ public abstract class Member extends BaseTimeEntity {
     private String phoneNumber;
 
     //프로필 이미지
-    @Column(nullable = true) // 회원가입시 입력받지 않으므로 기본 null
+    @Column(name = "profile_img_url", nullable = true) // 회원가입시 입력받지 않으므로 기본 null
     private String profileImgUrl;
 
 

--- a/src/main/java/com/my_medi/domain/member/entity/Role.java
+++ b/src/main/java/com/my_medi/domain/member/entity/Role.java
@@ -1,0 +1,14 @@
+package com.my_medi.domain.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    USER("ROLE_USER", "type_user"), EXPERT("ROLE_EXPERT", "type_expert");
+
+    private final String key; // Spring Security용 권한 키
+    private final String discriminator; // JPA 상속용 구분 값
+}

--- a/src/main/java/com/my_medi/domain/member/entity/Role.java
+++ b/src/main/java/com/my_medi/domain/member/entity/Role.java
@@ -1,5 +1,6 @@
 package com.my_medi.domain.member.entity;
 
+import com.my_medi.common.consts.StaticVariable;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,8 +8,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Role {
 
-    USER("ROLE_USER", "type_user"), EXPERT("ROLE_EXPERT", "type_expert");
+    ROLE_USER("ROLE_USER", StaticVariable.USER), ROLE_EXPERT("ROLE_EXPERT", StaticVariable.EXPERT);
 
     private final String key; // Spring Security용 권한 키
     private final String discriminator; // JPA 상속용 구분 값
+
 }

--- a/src/main/java/com/my_medi/domain/user/entity/User.java
+++ b/src/main/java/com/my_medi/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.my_medi.domain.user.entity;
 
 import com.my_medi.domain.member.entity.Member;
+import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
@@ -8,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -18,4 +20,17 @@ import lombok.experimental.SuperBuilder;
 public class User extends Member {
 
     private String userUuid;
+
+    private LocalDate birthDate;
+
+    private Float height;
+
+    private Float weight;
+
+    // TODO: 나중에 건강검진 리포트 기능 생기면 연관관계 추가
+    // @OneToMany(mappedBy = "user")
+    // private List<HealthReport> reports = new ArrayList<>();
+
+
+
 }

--- a/src/main/java/com/my_medi/domain/user/entity/User.java
+++ b/src/main/java/com/my_medi/domain/user/entity/User.java
@@ -1,6 +1,6 @@
 package com.my_medi.domain.user.entity;
 
-import com.my_medi.domain.Discriminator;
+import com.my_medi.common.consts.StaticVariable;
 import com.my_medi.domain.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
@@ -10,14 +10,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import java.time.LocalDate;
 
 @Entity
 @Getter
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@DiscriminatorValue(Discriminator.USER)      //TODO ROLE ENUM key값으로
+@DiscriminatorValue(StaticVariable.USER)      //TODO ROLE ENUM key값으로
 public class User extends Member {
 
     @Column(unique = true)

--- a/src/main/java/com/my_medi/domain/user/entity/User.java
+++ b/src/main/java/com/my_medi/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.my_medi.domain.user.entity;
 
+import com.my_medi.domain.Discriminator;
 import com.my_medi.domain.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
@@ -16,15 +17,16 @@ import java.time.LocalDate;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@DiscriminatorValue("type_user")      //TODO ROLE ENUM key값으로
+@DiscriminatorValue(Discriminator.USER)      //TODO ROLE ENUM key값으로
 public class User extends Member {
 
+    @Column(unique = true)
     private String userUuid;
 
-    private LocalDate birthDate;
-
+    //키
     private Float height;
 
+    //몸무게
     private Float weight;
 
     // TODO: 나중에 건강검진 리포트 기능 생기면 연관관계 추가


### PR DESCRIPTION
## #️⃣ 요약 설명

## 📝 작업 내용

연관관계 제외하고 user, member, expert erd 설계하였습니다.
member entity는 회원가입 기준으로 받는 공통 정보를 중심으로 하였고
expert, user는 개인과 전문가의 my page에서 확인되는 정보를 중심으로 하였습니다.

## 동작 확인

> 기능을 실행했을 때 정상 동작하는지 여부를 확인하고 사진을 올려주세요

<img width="981" alt="스크린샷 2025-07-06 오후 3 40 44" src="https://github.com/user-attachments/assets/fe679165-9238-43cb-ae1b-a7ece96cd39a" />


## 💬 리뷰 요구사항(선택)

> erd를 제대로 작성한게 맞는지, 개선해야할 부분이 있는지 확인 부탁드립니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 전문가(Expert) 정보에 고유 식별자, 전문 분야, 소속 기관명, 자격증 파일 URL, 자기소개 필드가 추가되었습니다.
  * 회원(Member) 정보에 역할, 이름, 생년월일, 성별, 닉네임, 로그인 ID, 비밀번호, 이메일, 전화번호, 프로필 이미지 URL 필드가 추가되었습니다.
  * 사용자(User) 정보에 고유 식별자가 추가되고, 생년월일 필드는 제거되었습니다.
  * 역할(Role), 성별(Gender), 전문 분야(Specialty)를 위한 새로운 열거형이 도입되었습니다.
  * 유효성 검증을 위한 Jakarta Validation API 의존성이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->