### PR TITLE
[MEDI-33] GlobalException Handler

### DIFF
--- a/src/main/java/com/my_medi/api/common/advice/ExceptionAdvice.java
+++ b/src/main/java/com/my_medi/api/common/advice/ExceptionAdvice.java
@@ -1,0 +1,126 @@
+package com.my_medi.api.common.advice;
+
+import com.my_medi.api.common.dto.ApiResponseDto;
+import com.my_medi.common.exception.ErrorStatus;
+import com.my_medi.common.exception.GeneralException;
+import com.my_medi.common.exception.Reason;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+//@Hidden
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY, request);
+    }
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().stream()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage,
+                            (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e, HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"), request, errors);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        e.printStackTrace();
+
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY,
+                ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(), request, e.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        Reason errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException, errorReasonHttpStatus, null, request);
+    }
+
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, Reason reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+
+        ApiResponseDto<Object> body = ApiResponseDto.onFailure(reason.getCode(), reason.getMessage(), null);
+
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status,
+                                                                WebRequest request, String errorPoint) {
+        ApiResponseDto<Object> body = ApiResponseDto.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(),
+                errorPoint);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers,
+                                                               ErrorStatus errorCommonStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponseDto<Object> body = ApiResponseDto.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(),
+                errorArgs);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponseDto<Object> body = ApiResponseDto.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(),
+                null);
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/com/my_medi/api/common/dto/ApiResponseDto.java
+++ b/src/main/java/com/my_medi/api/common/dto/ApiResponseDto.java
@@ -1,0 +1,29 @@
+package com.my_medi.api.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.my_medi.common.exception.BaseCode;
+import com.my_medi.common.exception.SuccessStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponseDto<T> {
+    private final Boolean isSuccess;
+    private final Integer code;
+    private final String message;
+    private T result;
+
+    public static <T> ApiResponseDto<T> onSuccess(T result) {
+        return new ApiResponseDto<>(true, 2000, SuccessStatus._SUCCESS.getMessage(), result);
+    }
+
+    public static <T> ApiResponseDto<T> of(BaseCode code, T result) {
+        return new ApiResponseDto<>(true, code.getReasonHttpStatus().getCode(), code.getReasonHttpStatus().getMessage(), result);
+    }
+
+    public static <T> ApiResponseDto<T> onFailure(Integer code, String message, T data) {
+        return new ApiResponseDto<>(false, code, message, data);
+    }
+}

--- a/src/main/java/com/my_medi/api/common/example/TestApiController.java
+++ b/src/main/java/com/my_medi/api/common/example/TestApiController.java
@@ -1,0 +1,38 @@
+package com.my_medi.api.common.example;
+
+import com.my_medi.common.exception.ErrorStatus;
+import com.my_medi.common.exception.GeneralException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/test")
+@RequiredArgsConstructor
+public class TestApiController {
+
+    @GetMapping
+    public TestDto test(@RequestParam String message) {
+        TestDto dto = new TestDto(message);
+
+        return dto;
+    }
+
+    @GetMapping("/exceptions")
+    public void testException() {
+        throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
+    }
+
+
+    @Getter
+    private class TestDto{
+        private String message;
+
+        public TestDto(String message) {
+            this.message = message;
+        }
+    }
+}

--- a/src/main/java/com/my_medi/api/user/controller/UserApiController.java
+++ b/src/main/java/com/my_medi/api/user/controller/UserApiController.java
@@ -1,9 +1,11 @@
 package com.my_medi.api.user.controller;
 
 import com.my_medi.domain.user.entity.User;
+import com.my_medi.domain.user.exception.UserHandler;
 import com.my_medi.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,16 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UserApiController {
 
-    //지금은 테스트를 위해 레포지토리 의존성 주입을 해둔 상태입니다
-    private final UserRepository userRepository;
 
     //TODO remove this method
-    @Transactional
-    @PostMapping
-    public Long registerUserForTest() {
-        return userRepository.save(User
-                .builder()
-                .userUuid("test")
-                .build()).getId();
+    @GetMapping
+    public void registerUserForTest() {
+        throw UserHandler.NOT_FOUND;
     }
 }

--- a/src/main/java/com/my_medi/common/annotation/ExplainError.java
+++ b/src/main/java/com/my_medi/common/annotation/ExplainError.java
@@ -1,0 +1,13 @@
+package com.my_medi.common.annotation;
+
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface ExplainError {
+    String value() default "";
+}

--- a/src/main/java/com/my_medi/common/exception/BaseCode.java
+++ b/src/main/java/com/my_medi/common/exception/BaseCode.java
@@ -1,0 +1,7 @@
+package com.my_medi.common.exception;
+
+public interface BaseCode {
+    Reason getReason();
+
+    Reason getReasonHttpStatus();
+}

--- a/src/main/java/com/my_medi/common/exception/BaseErrorCode.java
+++ b/src/main/java/com/my_medi/common/exception/BaseErrorCode.java
@@ -1,0 +1,5 @@
+package com.my_medi.common.exception;
+
+public interface BaseErrorCode extends BaseCode{
+    String getExplainError() throws NoSuchFieldException;
+}

--- a/src/main/java/com/my_medi/common/exception/ErrorStatus.java
+++ b/src/main/java/com/my_medi/common/exception/ErrorStatus.java
@@ -1,0 +1,59 @@
+package com.my_medi.common.exception;
+
+import com.my_medi.common.annotation.ExplainError;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.lang.reflect.Field;
+import java.util.Objects;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode{
+
+    // 서버 오류
+    @ExplainError("500번대 알수없는 오류입니다. 서버 관리자에게 문의 주세요")
+    _INTERNAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, 5000, "서버 에러, 관리자에게 문의 바랍니다."),
+    @ExplainError("인증이 필요없는 api입니다.")
+    _UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR(INTERNAL_SERVER_ERROR, 5001, "서버 에러, 로그인이 필요없는 요청입니다."),
+    _ASSIGNABLE_PARAMETER(BAD_REQUEST, 5002, "인증타입이 잘못되어 할당이 불가능합니다."),
+
+    // 일반적인 요청 오류
+    _BAD_REQUEST(BAD_REQUEST, 4000, "잘못된 요청입니다."),
+    _UNAUTHORIZED(UNAUTHORIZED, 4001, "로그인이 필요합니다."),
+    _FORBIDDEN(FORBIDDEN, 4002, "금지된 요청입니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+
+
+    @Override
+    public Reason getReason() {
+        return Reason.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public Reason getReasonHttpStatus() {
+        return Reason.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldException {
+        Field field = this.getClass().getField(this.name());
+        ExplainError annotation = field.getAnnotation(ExplainError.class);
+        return Objects.nonNull(annotation) ? annotation.value() : this.getMessage();
+    }
+}

--- a/src/main/java/com/my_medi/common/exception/GeneralException.java
+++ b/src/main/java/com/my_medi/common/exception/GeneralException.java
@@ -1,0 +1,24 @@
+package com.my_medi.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException{
+    private BaseErrorCode code;
+
+    @Override
+    public String getMessage() {
+        return code.getReason().getMessage();
+    }
+
+    public Reason getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public Reason getErrorReasonHttpStatus() {
+        return this.code.getReasonHttpStatus();
+    }
+
+}

--- a/src/main/java/com/my_medi/common/exception/Reason.java
+++ b/src/main/java/com/my_medi/common/exception/Reason.java
@@ -1,0 +1,17 @@
+package com.my_medi.common.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.util.HashMap;
+
+@Getter
+@Builder
+public class Reason {
+    private HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final Integer code;
+    private final String message;
+    private final HashMap<String, String> result;
+}

--- a/src/main/java/com/my_medi/common/exception/SuccessStatus.java
+++ b/src/main/java/com/my_medi/common/exception/SuccessStatus.java
@@ -1,0 +1,37 @@
+package com.my_medi.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode{
+    _SUCCESS(OK, 2000, "성공");
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+
+    @Override
+    public Reason getReason() {
+        return Reason.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public Reason getReasonHttpStatus() {
+        return Reason.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build();
+    }
+
+}

--- a/src/main/java/com/my_medi/domain/user/exception/UserErrorStatus.java
+++ b/src/main/java/com/my_medi/domain/user/exception/UserErrorStatus.java
@@ -1,6 +1,8 @@
-package com.my_medi.common.exception;
+package com.my_medi.domain.user.exception;
 
 import com.my_medi.common.annotation.ExplainError;
+import com.my_medi.common.exception.BaseErrorCode;
+import com.my_medi.common.exception.Reason;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -8,30 +10,19 @@ import org.springframework.http.HttpStatus;
 import java.lang.reflect.Field;
 import java.util.Objects;
 
-import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
 @AllArgsConstructor
-public enum ErrorStatus implements BaseErrorCode{
+public enum UserErrorStatus implements BaseErrorCode {
 
-    // 서버 오류
-    @ExplainError("500번대 알수없는 오류입니다. 서버 관리자에게 문의 주세요")
-    _INTERNAL_SERVER_ERROR(INTERNAL_SERVER_ERROR, 5000, "서버 에러, 관리자에게 문의 바랍니다."),
-    @ExplainError("인증이 필요없는 api입니다.")
-    _UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR(INTERNAL_SERVER_ERROR, 5001, "서버 에러, 로그인이 필요없는 요청입니다."),
-    _ASSIGNABLE_PARAMETER(BAD_REQUEST, 5002, "인증타입이 잘못되어 할당이 불가능합니다."),
-
-    // 일반적인 요청 오류
-    _BAD_REQUEST(BAD_REQUEST, 4000, "잘못된 요청입니다."),
-    _UNAUTHORIZED(UNAUTHORIZED, 4001, "로그인이 필요합니다."),
-    _FORBIDDEN(FORBIDDEN, 4002, "금지된 요청입니다.");
-
-    //user (4050-4099)
+    // entity MEMBER (4050-4099)
+    USER_NOT_FOUND(NOT_FOUND, 4050, "회원을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;
     private final String message;
-
 
     @Override
     public Reason getReason() {

--- a/src/main/java/com/my_medi/domain/user/exception/UserHandler.java
+++ b/src/main/java/com/my_medi/domain/user/exception/UserHandler.java
@@ -1,0 +1,14 @@
+package com.my_medi.domain.user.exception;
+
+import com.my_medi.common.exception.BaseErrorCode;
+import com.my_medi.common.exception.ErrorStatus;
+import com.my_medi.common.exception.GeneralException;
+
+public class UserHandler extends GeneralException {
+
+    public static final GeneralException NOT_FOUND
+            = new UserHandler(UserErrorStatus.USER_NOT_FOUND);
+    public UserHandler(BaseErrorCode code) {
+        super(code);
+    }
+}


### PR DESCRIPTION
## #️⃣ 요약 설명
> 프로젝트 전역 예외처리 구현
## 📝 작업 내용

- common 패키지에 exception 기본구성 생성
- domain 패키지에 각 도메인의 errorstatus와 handler 구현
- api 패키지에 exception advice 구현


### 사용 방법
<img width="222" alt="image" src="https://github.com/user-attachments/assets/6471282f-d3ae-4829-a02f-bbb507aa7038" />

<img width="408" alt="image" src="https://github.com/user-attachments/assets/6b70961d-22c6-48d5-b078-139445896b61" />

<img width="736" alt="image" src="https://github.com/user-attachments/assets/6a6355d1-91ed-4b13-84d9-5ca24caabe94" />

<img width="643" alt="image" src="https://github.com/user-attachments/assets/133a1712-a602-4b3d-bdb9-c56c48a7f832" />


## 동작 확인
<img width="387" alt="image" src="https://github.com/user-attachments/assets/6be8cdd6-3a8f-4295-8792-720a39ef6e03" />


## 💬 리뷰 요구사항(선택)

각 도메인별로 handler 생성해주시고 해당 클래스 내에 지역변수로 에러 객체 생성해주세요! 그리고 사진처럼 예외 상황때 던져주시면 좀더 깔끔하게 사용할 수 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 표준화된 API 응답 구조(`ApiResponseDto`)가 도입되어 성공 및 실패 응답이 일관되게 제공됩니다.
  * 중앙 집중식 예외 처리(`ExceptionAdvice`)로 유효성 검사, 일반 예외, 커스텀 예외에 대해 통일된 에러 응답이 반환됩니다.
  * 사용자 도메인 전용 에러 코드(`UserErrorStatus`) 및 예외(`UserHandler`)가 추가되었습니다.
  * 에러 코드, 성공 코드, 설명 어노테이션 등 상세한 예외 및 응답 관리 체계가 마련되었습니다.
  * 테스트용 API 컨트롤러가 추가되어 예외 처리 및 응답 구조를 쉽게 확인할 수 있습니다.

* **버그 수정**
  * 사용자 테스트 등록 API가 더 이상 실제 저장 동작 없이 예외를 반환하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->