### PR TITLE
[MEDI-35] Domain Layer for Member/User/Expert

### DIFF
--- a/src/main/java/com/my_medi/domain/expert/repository/ExpertRepository.java
+++ b/src/main/java/com/my_medi/domain/expert/repository/ExpertRepository.java
@@ -1,0 +1,16 @@
+package com.my_medi.domain.expert.repository;
+
+import com.my_medi.domain.expert.entity.Expert;
+import com.my_medi.domain.expert.entity.Specialty;
+import com.my_medi.domain.member.repository.MemberRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+// MemberRepository 상속
+public interface ExpertRepository extends MemberRepository<Expert> {
+    //MemberRepository에 없는 Expert 메서드
+    Optional<Expert> findByExpertUuid(String expertUuid);
+    List<Expert> findBySpecialty(Specialty specialty);
+
+}

--- a/src/main/java/com/my_medi/domain/expert/service/ExpertService.java
+++ b/src/main/java/com/my_medi/domain/expert/service/ExpertService.java
@@ -1,0 +1,30 @@
+package com.my_medi.domain.expert.service;
+
+import com.my_medi.domain.expert.entity.Expert;
+import com.my_medi.domain.expert.entity.Specialty;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ExpertService {
+
+    Expert save(Expert expert);
+
+    Optional<Expert> findById(Long id);
+
+    List<Expert> findAll();
+
+    void deleteById(Long id);
+
+    Optional<Expert> findByLoginId(String loginId);
+
+    Optional<Expert> findByNickname(String nickname);
+
+    boolean existsByNickname(String nickname);
+
+    boolean existsByEmail(String email);
+
+    Optional<Expert> findByExpertUuid(String expertUuid);
+
+    List<Expert> findBySpecialty(Specialty specialty);
+}

--- a/src/main/java/com/my_medi/domain/expert/service/ExpertServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/expert/service/ExpertServiceImpl.java
@@ -1,0 +1,67 @@
+package com.my_medi.domain.expert.service;
+
+import com.my_medi.domain.expert.entity.Expert;
+import com.my_medi.domain.expert.entity.Specialty;
+import com.my_medi.domain.expert.repository.ExpertRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ExpertServiceImpl implements ExpertService {
+
+    private final ExpertRepository expertRepository;
+
+    @Override
+    public Expert save(Expert expert) {
+        return expertRepository.save(expert);
+    }
+
+    @Override
+    public Optional<Expert> findById(Long id) {
+        return expertRepository.findById(id);
+    }
+
+    @Override
+    public List<Expert> findAll() {
+        return expertRepository.findAll();
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        expertRepository.deleteById(id);
+    }
+
+    @Override
+    public Optional<Expert> findByLoginId(String loginId) {
+        return expertRepository.findByLoginId(loginId);
+    }
+
+    @Override
+    public Optional<Expert> findByNickname(String nickname) {
+        return expertRepository.findByNickname(nickname);
+    }
+
+    @Override
+    public boolean existsByNickname(String nickname) {
+        return expertRepository.existsByNickname(nickname);
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return expertRepository.existsByEmail(email);
+    }
+
+    @Override
+    public Optional<Expert> findByExpertUuid(String expertUuid) {
+        return expertRepository.findByExpertUuid(expertUuid);
+    }
+
+    @Override
+    public List<Expert> findBySpecialty(Specialty specialty) {
+        return expertRepository.findBySpecialty(specialty);
+    }
+}

--- a/src/main/java/com/my_medi/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/my_medi/domain/member/repository/MemberRepository.java
@@ -1,0 +1,15 @@
+package com.my_medi.domain.member.repository;
+
+import com.my_medi.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+
+import java.util.Optional;
+
+@NoRepositoryBean // 사용한 이유 : 인터페이스가 직접 Bean으로 등록되지 않고 UserRepository, ExpertRepository에서 상속해서 사용할 수 있도록
+public interface MemberRepository<T extends Member> extends JpaRepository<T, Long> {
+    Optional<T> findByLoginId(String loginId);//loginId(아이디)로 회원 찾기
+    Optional<T> findByNickname(String nickname);//nickname으로 회원을 찾는다.
+    boolean existsByNickname(String nickname); // 회원가입 시 닉네임 중복 체크할 때 사용
+    boolean existsByEmail(String email); // 이 이메일을 가진 회원이 DB에 존재하는지 확인한다.
+}

--- a/src/main/java/com/my_medi/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/my_medi/domain/user/repository/UserRepository.java
@@ -1,7 +1,13 @@
 package com.my_medi.domain.user.repository;
 
+import com.my_medi.domain.member.repository.MemberRepository;
 import com.my_medi.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User,Long> {
+import java.util.Optional;
+
+//MemberRepository 상속
+public interface UserRepository extends MemberRepository<User> {
+    // MemberRepository에 없는 User 메서드
+    Optional<User> findByUserUuid(String userUuid);
 }

--- a/src/main/java/com/my_medi/domain/user/service/UserService.java
+++ b/src/main/java/com/my_medi/domain/user/service/UserService.java
@@ -1,0 +1,27 @@
+package com.my_medi.domain.user.service;
+
+import com.my_medi.domain.user.entity.User;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserService {
+
+    Optional<User> findByUserUuid(String uuid);
+
+    User save(User user);
+
+    Optional<User> findById(Long id);
+
+    List<User> findAll();
+
+    void deleteById(Long id);
+
+    Optional<User> findByLoginId(String loginId);
+
+    Optional<User> findByNickname(String nickname);
+
+    boolean existsByNickname(String nickname);
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/my_medi/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,62 @@
+package com.my_medi.domain.user.service;
+
+import com.my_medi.domain.user.entity.User;
+import com.my_medi.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    //토큰 Uuid 조회(DTO엔 절대 x, Converter or service에서 생성)
+    @Override
+    public Optional<User> findByUserUuid(String uuid) {
+        return userRepository.findByUserUuid(uuid);
+    }
+
+    @Override
+    public User save(User user) {
+        return userRepository.save(user);
+    }
+
+    @Override
+    public Optional<User> findById(Long id) {
+        return userRepository.findById(id);
+    }
+
+    @Override
+    public List<User> findAll() {
+        return userRepository.findAll();
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        userRepository.deleteById(id);
+    }
+
+    @Override
+    public Optional<User> findByLoginId(String loginId) {
+        return userRepository.findByLoginId(loginId);
+    }
+
+    @Override
+    public Optional<User> findByNickname(String nickname) {
+        return userRepository.findByNickname(nickname);
+    }
+
+    @Override
+    public boolean existsByNickname(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return userRepository.existsByEmail(email);
+    }
+}


### PR DESCRIPTION
## #️⃣ 요약 설명
domain 패키지 작업(entity, repository, service)

## 📝 작업 내용

domain 패키지에 entity, repository, service까지만 구현하였습니다 
Security, DTO, Controller는 추후 도입 예정으로 Service는 지금은 단순한 CRUD 중심으로만 구성하였습니다.

공통 로직은 MemberRepository<T extends Member>에 정의하였고 UserRepository, ExpertRepository는 이를 상속하고, 각 도메인 전용 메서드를 따로 선언하였습니다

## 동작 확인
<img width="1277" alt="스크린샷 2025-07-10 오후 12 15 03" src="https://github.com/user-attachments/assets/0f31a763-c4f6-4169-b28f-731f0d0e51e4" />

> 기능 실행 시 정상 동작합니다

## 💬 리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 전문가 및 사용자 정보를 조회, 저장, 삭제할 수 있는 서비스 및 저장소 기능이 추가되었습니다.
  * 닉네임, 이메일, UUID, 전문분야 등 다양한 조건으로 전문가 및 사용자 검색이 가능합니다.
  * 닉네임 및 이메일 중복 여부 확인 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->