### PR TITLE
[MEDI-51] Split auth/authz APIs role

### DIFF
--- a/src/main/java/com/my_medi/security/config/SecurityConfig.java
+++ b/src/main/java/com/my_medi/security/config/SecurityConfig.java
@@ -83,11 +83,7 @@ public class SecurityConfig {
     //[GET] 인증 없이 접근 허용할 경로 목록
     private String[] permitAllGetPaths() {
         return new String[]{
-                "/",
                 "/api/v1/tokens/login",
-                "/api/v1/users/{userId}",
-                "/api/v1/user/proposal",
-                "/api/v1/experts/{expertId}",
                 "/api/v1/test",
                 "/api/v1/test/exceptions",
                 "/api/v1/examples/user",
@@ -98,9 +94,7 @@ public class SecurityConfig {
     //[POST] 인증 없이 접근 허용할 경로 목록
     private String[] permitAllPostPaths() {
         return new String[]{
-                "/api/v1/tokens/reissue",
-                "/api/v1/users", //post는 비인증, get은 인증
-                "/api/v1/experts" //post는 비인증, get은 인증
+                "/api/v1/tokens/reissue"
         };
     }
 


### PR DESCRIPTION
## #️⃣ 요약 설명
인증/비인증 api 나누기(SecurityConfig 수정)

## 📝 작업 내용

```java

    //[GET] 인증 없이 접근 허용할 경로 목록
    private String[] permitAllGetPaths() {
        return new String[]{
                "/",
                "/api/v1/tokens/login",
                "/api/v1/test",
                "/api/v1/test/exceptions",
                "/api/v1/examples/user",
                "/api/v1/examples/global"
        };
    }

    //[POST] 인증 없이 접근 허용할 경로 목록
    private String[] permitAllPostPaths() {
        return new String[]{
                "/api/v1/tokens/reissue",
        };
    }

```

GET, POST 요청을 나누어 비인증api를 추가하였고 addFilter, configureExceptionHandling 함수를 추가하여 인증api를 비인증상태로 get, post요청했을때 400에러가 발생하도록 수정하였습니다.

## 동작 확인

# 인증api 예시
<img width="828" height="771" alt="인증api예시" src="https://github.com/user-attachments/assets/b8f8026d-abde-403a-a3ae-8c78bdf260eb" />

# 비인증api 예시
<img width="838" height="799" alt="비인증api예시" src="https://github.com/user-attachments/assets/10fec21f-e210-4879-8b66-51aab8d7f21c" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * JWT 기반 인증 및 예외 처리가 도입되어 보안이 강화되었습니다.
  * 인증 없이 접근 가능한 API 경로가 명확하게 지정되었습니다.
  * Swagger UI 및 OAuth2 관련 경로에 대한 접근이 허용되었습니다.

* **개선 사항**
  * 인증되지 않은 요청에 대한 기본 정책이 변경되어, 명시적으로 허용된 경로를 제외한 모든 요청에 인증이 필요합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->