### PR TITLE
[MEDI-60] refactoring schedule controller

### DIFF
--- a/src/main/java/com/my_medi/api/consultation/controller/UserConsultationApiController.java
+++ b/src/main/java/com/my_medi/api/consultation/controller/UserConsultationApiController.java
@@ -32,4 +32,6 @@ public class UserConsultationApiController {
     //TODO 본인과 매칭된 상담 목록 조회(only status = ACCEPTED)
 
     //TODO 본인이 요청한 상담 취소(only status = REQUESTED)
+
+    //TODO: 상담 요청 목록 조회 and accepted 합쳐서 status별로 조회할 수 있도록 수정
 }

--- a/src/main/java/com/my_medi/api/consultation/controller/UserConsultationApiController.java
+++ b/src/main/java/com/my_medi/api/consultation/controller/UserConsultationApiController.java
@@ -31,15 +31,20 @@ public class UserConsultationApiController {
     public ApiResponseDto<Long> approveConsultation(@AuthUser User user,
                                                     @PathVariable Long expertId,
                                                     @RequestParam String comment) {
-        //TODO user.getId() -> user(entity) convert
+
         return ApiResponseDto.onSuccess(consultationRequestCommandService
                 .requestConsultationToExpert(user, expertId, comment));
     }
 
-    @Operation(summary = "본인이 요청한 모든 상담 요청 목록을 조회합니다.")
-    @GetMapping("/all")
-    public ApiResponseDto<List<UserConsultationDto>> getAllMyConsultations(@AuthUser User user) {
-        List<ConsultationRequest> requests = consultationRequestQueryService.getAllRequestByUser(user.getId());
+    @Operation(summary = "본인이 요청한 상담 목록을 조회합니다.")
+    @GetMapping
+    public ApiResponseDto<List<UserConsultationDto>> getMyConsultations(
+            @AuthUser User user,
+            @RequestParam(required = false) RequestStatus status
+    ) {
+        List<ConsultationRequest> requests = (status == null) ?
+                consultationRequestQueryService.getAllRequestByUser(user.getId()) :
+                consultationRequestQueryService.getRequestByUser(user.getId(), status);
 
         List<UserConsultationDto> dtoList = requests.stream()
                 .map(UserConsultationConvert::toDto)
@@ -48,20 +53,6 @@ public class UserConsultationApiController {
         return ApiResponseDto.onSuccess(dtoList);
     }
 
-    //TODO 본인과 매칭된 상담 목록 조회(only status = ACCEPTED)
-
-    @Operation(summary = "본인과 매칭된 상담 목록을 조회합니다. (status = ACCEPTED)")
-    @GetMapping("/accepted")
-    public ApiResponseDto<List<UserConsultationDto>> getMatchedConsultations(@AuthUser User user) {
-        List<ConsultationRequest> acceptedRequests =
-                consultationRequestQueryService.getRequestByUser(user.getId(), RequestStatus.ACCEPTED);
-
-        List<UserConsultationDto> dtoList = acceptedRequests.stream()
-                .map(UserConsultationConvert::toDto)
-                .toList();
-
-        return ApiResponseDto.onSuccess(dtoList);
-    }
 
 
     @Operation(summary = "본인이 요청한 상담을 취소합니다.")

--- a/src/main/java/com/my_medi/api/schedule/controller/ExpertScheduleApiController.java
+++ b/src/main/java/com/my_medi/api/schedule/controller/ExpertScheduleApiController.java
@@ -36,11 +36,14 @@ public class ExpertScheduleApiController {
                 .registerScheduleToUser(expert, userId, registerScheduleDto));
     }
 
-    //TODO 월 단위로 조회 가능하도록 수정
-    @Operation(summary = "전문가가 본인 스케줄을 조회합니다.")
+    @Operation(summary = "전문가가 본인 스케줄을 월 단위로 조회합니다.")
     @GetMapping
-    public ApiResponseDto<ScheduleResponseDto.ScheduleListDto> getAllSchedule(@AuthExpert Expert expert) {
-        List<Schedule> expertSchedules = scheduleQueryService.getExpertSchedules(expert.getId());
+    public ApiResponseDto<ScheduleResponseDto.ScheduleListDto> getMonthlySchedule(
+            @AuthExpert Expert expert,
+            @RequestParam int year,
+            @RequestParam int month) {
+
+        List<Schedule> expertSchedules = scheduleQueryService.getExpertSchedulesByMonth(expert.getId(), year, month);
         return ApiResponseDto.onSuccess(ScheduleMapper.toScheduleListDto(expertSchedules));
     }
 

--- a/src/main/java/com/my_medi/api/schedule/controller/ExpertScheduleApiController.java
+++ b/src/main/java/com/my_medi/api/schedule/controller/ExpertScheduleApiController.java
@@ -6,10 +6,12 @@ import com.my_medi.api.schedule.dto.ScheduleResponseDto;
 import com.my_medi.api.schedule.dto.ScheduleResponseDto.ScheduleSummaryDto;
 import com.my_medi.api.schedule.mapper.ScheduleMapper;
 import com.my_medi.common.annotation.AuthExpert;
+import com.my_medi.common.annotation.AuthUser;
 import com.my_medi.domain.expert.entity.Expert;
 import com.my_medi.domain.schedule.entity.Schedule;
 import com.my_medi.domain.schedule.service.ScheduleCommandService;
 import com.my_medi.domain.schedule.service.ScheduleQueryService;
+import com.my_medi.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -54,6 +56,21 @@ public class ExpertScheduleApiController {
             @PathVariable Long scheduleId) {
         scheduleCommandService.removeSchedule(expert.getId(), scheduleId);
         return ApiResponseDto.onSuccess(scheduleId);
+    }
+
+    @Operation(summary = "전문가의 가장 임박한 3개의 스케줄을 조회합니다.")
+    @GetMapping("/upcoming")
+    public ApiResponseDto<List<ScheduleResponseDto.ScheduleSummaryDto>> getUpcomingSchedules(
+            @AuthExpert Expert expert) {
+
+        List<Schedule> upcomingSchedules = scheduleQueryService.getUpcomingSchedulesForExpert(expert.getId());
+
+        List<ScheduleResponseDto.ScheduleSummaryDto> dtoList =
+                upcomingSchedules.stream()
+                        .map(ScheduleMapper::toScheduleSummaryDto)
+                        .toList();
+
+        return ApiResponseDto.onSuccess(dtoList);
     }
 
 }

--- a/src/main/java/com/my_medi/api/schedule/controller/ExpertScheduleApiController.java
+++ b/src/main/java/com/my_medi/api/schedule/controller/ExpertScheduleApiController.java
@@ -32,9 +32,8 @@ public class ExpertScheduleApiController {
             @AuthExpert Expert expert,
             @PathVariable Long userId,
             @RequestBody RegisterScheduleDto registerScheduleDto) {
-        //TODO expert.getId() -> expert(entity) convert
         return ApiResponseDto.onSuccess(scheduleCommandService
-                .registerScheduleToUser(expert.getId(), userId, registerScheduleDto));
+                .registerScheduleToUser(expert, userId, registerScheduleDto));
     }
 
     //TODO 월 단위로 조회 가능하도록 수정

--- a/src/main/java/com/my_medi/api/schedule/controller/UserScheduleApiController.java
+++ b/src/main/java/com/my_medi/api/schedule/controller/UserScheduleApiController.java
@@ -3,9 +3,7 @@ package com.my_medi.api.schedule.controller;
 import com.my_medi.api.common.dto.ApiResponseDto;
 import com.my_medi.api.schedule.dto.ScheduleResponseDto;
 import com.my_medi.api.schedule.mapper.ScheduleMapper;
-import com.my_medi.common.annotation.AuthExpert;
 import com.my_medi.common.annotation.AuthUser;
-import com.my_medi.domain.expert.entity.Expert;
 import com.my_medi.domain.schedule.entity.Schedule;
 import com.my_medi.domain.schedule.service.ScheduleQueryService;
 import com.my_medi.domain.user.entity.User;
@@ -38,6 +36,19 @@ public class UserScheduleApiController {
         return ApiResponseDto.onSuccess(ScheduleMapper.toScheduleListDto(userSchedules));
     }
 
+    @Operation(summary = "사용자의 가장 임박한 3개의 스케줄을 조회합니다.")
+    @GetMapping("/upcoming")
+    public ApiResponseDto<List<ScheduleResponseDto.ScheduleSummaryDto>> getUpcomingSchedules(
+            @AuthUser User user) {
 
-    //TODO 대표 스케줄 3개 조회(상세 내용)
+        List<Schedule> upcomingSchedules = scheduleQueryService.getUpcomingSchedulesForUser(user.getId());
+
+        List<ScheduleResponseDto.ScheduleSummaryDto> dtoList =
+                upcomingSchedules.stream()
+                        .map(ScheduleMapper::toScheduleSummaryDto)
+                        .toList();
+
+        return ApiResponseDto.onSuccess(dtoList);
+    }
+
 }

--- a/src/main/java/com/my_medi/api/schedule/controller/UserScheduleApiController.java
+++ b/src/main/java/com/my_medi/api/schedule/controller/UserScheduleApiController.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;

--- a/src/main/java/com/my_medi/api/schedule/controller/UserScheduleApiController.java
+++ b/src/main/java/com/my_medi/api/schedule/controller/UserScheduleApiController.java
@@ -27,7 +27,7 @@ public class UserScheduleApiController {
 
     @Operation(summary = "사용자가 본인 스케줄을 월 단위로 조회합니다.")
     @GetMapping
-    public ApiResponseDto<ScheduleResponseDto.ScheduleListDto> getAllSchedule(
+    public ApiResponseDto<ScheduleResponseDto.ScheduleListDto> getMonthlySchedule(
             @AuthUser User user,
             @RequestParam int year,
             @RequestParam int month) {

--- a/src/main/java/com/my_medi/api/schedule/controller/UserScheduleApiController.java
+++ b/src/main/java/com/my_medi/api/schedule/controller/UserScheduleApiController.java
@@ -3,7 +3,9 @@ package com.my_medi.api.schedule.controller;
 import com.my_medi.api.common.dto.ApiResponseDto;
 import com.my_medi.api.schedule.dto.ScheduleResponseDto;
 import com.my_medi.api.schedule.mapper.ScheduleMapper;
+import com.my_medi.common.annotation.AuthExpert;
 import com.my_medi.common.annotation.AuthUser;
+import com.my_medi.domain.expert.entity.Expert;
 import com.my_medi.domain.schedule.entity.Schedule;
 import com.my_medi.domain.schedule.service.ScheduleQueryService;
 import com.my_medi.domain.user.entity.User;
@@ -12,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -24,14 +27,17 @@ public class UserScheduleApiController {
 
     private final ScheduleQueryService scheduleQueryService;
 
-
-    //TODO 월 단위로 조회 가능하도록 수정
-    @Operation(summary = "사용자가 본인 스케줄을 조회합니다.")
+    @Operation(summary = "사용자가 본인 스케줄을 월 단위로 조회합니다.")
     @GetMapping
-    public ApiResponseDto<ScheduleResponseDto.ScheduleListDto> getAllSchedule(@AuthUser User user) {
-        List<Schedule> userSchedules = scheduleQueryService.getUserSchedules(user.getId());
+    public ApiResponseDto<ScheduleResponseDto.ScheduleListDto> getAllSchedule(
+            @AuthUser User user,
+            @RequestParam int year,
+            @RequestParam int month) {
+
+        List<Schedule> userSchedules = scheduleQueryService.getUserSchedulesByMonth(user.getId(), year, month);
         return ApiResponseDto.onSuccess(ScheduleMapper.toScheduleListDto(userSchedules));
     }
+
 
     //TODO 대표 스케줄 3개 조회(상세 내용)
 }

--- a/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
@@ -13,4 +13,7 @@ public interface ConsultationRequestRepository extends JpaRepository<Consultatio
     List<ConsultationRequest> findByExpertIdAndRequestStatus(Long expertId, RequestStatus requestStatus);
 
     List<ConsultationRequest> findByExpertIdAndUserId(Long expertId, Long userId);
+
+    boolean existsByExpertIdAndUserIdAndRequestStatus(Long expertId, Long userId, RequestStatus requestStatus);
+
 }

--- a/src/main/java/com/my_medi/domain/schedule/exception/ScheduleErrorStatus.java
+++ b/src/main/java/com/my_medi/domain/schedule/exception/ScheduleErrorStatus.java
@@ -22,7 +22,11 @@ public enum ScheduleErrorStatus implements BaseErrorCode {
 
     EXPERT_NOT_FOUND(HttpStatus.NOT_FOUND, 4102, "전문가를 찾을 수 없습니다."),
 
-    SCHEDULE_ONLY_CAN_BE_TOUCHED_BY_EXPERT(HttpStatus.FORBIDDEN, 4103, "해당 일정은 해당 전문가만 수정 또는 삭제할 수 있습니다.");
+    SCHEDULE_ONLY_CAN_BE_TOUCHED_BY_EXPERT(HttpStatus.FORBIDDEN, 4103, "해당 일정은 해당 전문가만 수정 또는 삭제할 수 있습니다."),
+
+    NOT_MATCHED_CONSULTATION(HttpStatus.BAD_REQUEST, 4104, "전문가와 사용자가 매칭된 상담 상태가 아닙니다."),
+
+    ;
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/my_medi/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/my_medi/domain/schedule/repository/ScheduleRepository.java
@@ -3,7 +3,6 @@ package com.my_medi.domain.schedule.repository;
 import com.my_medi.domain.schedule.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -14,5 +13,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findByExpertId(Long expertId);
 
     List<Schedule> findByExpertIdAndStartTimeBetween(Long expertId, LocalDateTime start, LocalDateTime end);
+
+    List<Schedule> findByUserIdAndStartTimeBetween(Long userId, LocalDateTime start, LocalDateTime end);
 
 }

--- a/src/main/java/com/my_medi/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/my_medi/domain/schedule/repository/ScheduleRepository.java
@@ -4,6 +4,7 @@ import com.my_medi.domain.schedule.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
@@ -12,8 +13,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     List<Schedule> findByExpertId(Long expertId);
 
-    List<Schedule> findByExpertIdAndDateBetween(Long expertId, LocalDate startDate, LocalDate endDate);
-
-
+    List<Schedule> findByExpertIdAndStartTimeBetween(Long expertId, LocalDateTime start, LocalDateTime end);
 
 }

--- a/src/main/java/com/my_medi/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/my_medi/domain/schedule/repository/ScheduleRepository.java
@@ -3,6 +3,7 @@ package com.my_medi.domain.schedule.repository;
 import com.my_medi.domain.schedule.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
@@ -10,5 +11,9 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findByUserId(Long userId);
 
     List<Schedule> findByExpertId(Long expertId);
+
+    List<Schedule> findByExpertIdAndDateBetween(Long expertId, LocalDate startDate, LocalDate endDate);
+
+
 
 }

--- a/src/main/java/com/my_medi/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/my_medi/domain/schedule/repository/ScheduleRepository.java
@@ -16,4 +16,10 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     List<Schedule> findByUserIdAndStartTimeBetween(Long userId, LocalDateTime start, LocalDateTime end);
 
+    List<Schedule> findTop3ByExpertIdAndStartTimeAfterOrderByStartTimeAsc(Long expertId, LocalDateTime now);
+
+    List<Schedule> findTop3ByUserIdAndStartTimeAfterOrderByStartTimeAsc(Long userId, LocalDateTime now);
+
+
+
 }

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleCommandService.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleCommandService.java
@@ -2,9 +2,10 @@ package com.my_medi.domain.schedule.service;
 
 import com.my_medi.api.schedule.dto.EditScheduleDto;
 import com.my_medi.api.schedule.dto.RegisterScheduleDto;
+import com.my_medi.domain.expert.entity.Expert;
 
 public interface ScheduleCommandService {
-    Long registerScheduleToUser(Long expertId, Long userId, RegisterScheduleDto registerScheduleDto);
+    Long registerScheduleToUser(Expert expert, Long userId, RegisterScheduleDto registerScheduleDto);
 
 
     Long editSchedule(Long expertId, Long scheduleId , EditScheduleDto editScheduleDto);

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleCommandServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleCommandServiceImpl.java
@@ -32,7 +32,6 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
 
     @Override
     public Long registerScheduleToUser(Expert expert, Long userId, RegisterScheduleDto registerScheduleDto) {
-        //TODO expert와 user 사이에 approved된 consultation 존재 확인
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ScheduleHandler(ScheduleErrorStatus.USER_NOT_FOUND));
 

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleCommandServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleCommandServiceImpl.java
@@ -84,4 +84,6 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
 //            throw new ScheduleHandler(ScheduleErrorStatus.SCHEDULE_ONLY_CAN_BE_TOUCHED_BY_EXPERT);
 //        }
 //    }
+
+
 }

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryService.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryService.java
@@ -10,4 +10,7 @@ public interface ScheduleQueryService {
     List<Schedule> getUserSchedules(Long userId);
 
     List<Schedule> getExpertSchedules(Long expertId);
+
+    List<Schedule> getExpertSchedulesByMonth(Long expertId, int year, int month);
+
 }

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryService.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryService.java
@@ -15,4 +15,10 @@ public interface ScheduleQueryService {
 
     List<Schedule> getUserSchedulesByMonth(Long userId, int year, int month);
 
+    List<Schedule> getUpcomingSchedulesForUser(Long userId);
+
+    List<Schedule> getUpcomingSchedulesForExpert(Long expertId);
+
+
+
 }

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryService.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryService.java
@@ -13,4 +13,6 @@ public interface ScheduleQueryService {
 
     List<Schedule> getExpertSchedulesByMonth(Long expertId, int year, int month);
 
+    List<Schedule> getUserSchedulesByMonth(Long userId, int year, int month);
+
 }

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryServiceImpl.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Slf4j
@@ -26,5 +27,13 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
     @Override
     public List<Schedule> getExpertSchedules(Long expertId) {
         return scheduleRepository.findByExpertId(expertId);
+    }
+
+    @Override
+    public List<Schedule> getExpertSchedulesByMonth(Long expertId, int year, int month) {
+        LocalDate start = LocalDate.of(year, month, 1);
+        LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
+
+        return scheduleRepository.findByExpertIdAndDateBetween(expertId, start, end);
     }
 }

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryServiceImpl.java
@@ -41,4 +41,15 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
         return scheduleRepository.findByExpertIdAndStartTimeBetween(expertId, start, end);
     }
 
+    @Override
+    public List<Schedule> getUserSchedulesByMonth(Long userId, int year, int month){
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+
+        LocalDateTime start = startDate.atTime(23, 59, 59);
+        LocalDateTime end = endDate.atTime(23, 59, 59);
+
+        return scheduleRepository.findByUserIdAndStartTimeBetween(userId, start, end);
+    }
+
 }

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryServiceImpl.java
@@ -52,4 +52,26 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
         return scheduleRepository.findByUserIdAndStartTimeBetween(userId, start, end);
     }
 
+
+    private List<Schedule> findUpcomingSchedules(SortType type, Long id) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return switch (type) {
+            case USER -> scheduleRepository.findTop3ByUserIdAndStartTimeAfterOrderByStartTimeAsc(id, now);
+            case EXPERT -> scheduleRepository.findTop3ByExpertIdAndStartTimeAfterOrderByStartTimeAsc(id, now);
+        };
+    }
+
+    @Override
+    public List<Schedule> getUpcomingSchedulesForUser(Long userId) {
+        return findUpcomingSchedules(SortType.USER, userId);
+    }
+
+    @Override
+    public List<Schedule> getUpcomingSchedulesForExpert(Long expertId) {
+        return findUpcomingSchedules(SortType.EXPERT, expertId);
+    }
+
+    public enum SortType { USER, EXPERT }
+
 }

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryServiceImpl.java
@@ -46,7 +46,7 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
         LocalDate startDate = LocalDate.of(year, month, 1);
         LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
 
-        LocalDateTime start = startDate.atTime(23, 59, 59);
+        LocalDateTime start = startDate.atStartOfDay();
         LocalDateTime end = endDate.atTime(23, 59, 59);
 
         return scheduleRepository.findByUserIdAndStartTimeBetween(userId, start, end);

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -31,9 +32,13 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
 
     @Override
     public List<Schedule> getExpertSchedulesByMonth(Long expertId, int year, int month) {
-        LocalDate start = LocalDate.of(year, month, 1);
-        LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
 
-        return scheduleRepository.findByExpertIdAndDateBetween(expertId, start, end);
+        LocalDateTime start = startDate.atStartOfDay();
+        LocalDateTime end = endDate.atTime(23, 59, 59);
+
+        return scheduleRepository.findByExpertIdAndStartTimeBetween(expertId, start, end);
     }
+
 }


### PR DESCRIPTION
## #️⃣ 요약 설명
스케줄 요청 관련 로직 수정 및 TODO 구현

## 📝 작업 내용

> 전문가와 사용자의 월 별 스케줄 조회 및 가장 임박한 스케줄 최대 3개 조회하는 API 구현


## 동작 확인
<img width="1470" height="956" alt="스크린샷 2025-07-26 오후 3 48 37" src="https://github.com/user-attachments/assets/eee541fe-fa32-4d67-a50d-affb5df346ba" />
<img width="1470" height="956" alt="스크린샷 2025-07-26 오후 4 03 10" src="https://github.com/user-attachments/assets/501d9011-f682-4b6b-bcfa-876a979f72f8" />
<img width="1470" height="956" alt="스크린샷 2025-07-26 오후 4 49 16" src="https://github.com/user-attachments/assets/e6fe693b-633c-4a92-8df5-a2e2196b634e" />
<img width="1470" height="956" alt="스크린샷 2025-07-26 오후 5 02 53" src="https://github.com/user-attachments/assets/c84ab5dc-8139-4353-b9dd-ec799fa52838" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 전문가와 사용자가 각각 연도와 월별로 일정을 조회할 수 있는 기능이 추가되었습니다.
  * 전문가와 사용자가 각각 다가오는 3개의 일정을 확인할 수 있는 엔드포인트가 추가되었습니다.
  * 사용자 상담 요청 조회 시 상태별 필터링 기능이 추가되어, 전체 또는 특정 상태의 상담 요청을 선택적으로 조회할 수 있습니다.

* **버그 수정**
  * 전문가가 사용자에게 일정을 등록할 때, 매칭된 상담이 없는 경우 등록이 제한되도록 개선되었습니다.

* **기타**
  * 일정 관련 오류 메시지가 추가 및 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->