### PR TITLE
[MEDI-63] health checkup & edit security(login)

### DIFF
--- a/src/main/java/com/my_medi/api/common/example/TestApiController.java
+++ b/src/main/java/com/my_medi/api/common/example/TestApiController.java
@@ -1,11 +1,13 @@
 package com.my_medi.api.common.example;
 
+import com.my_medi.api.common.dto.ApiResponseDto;
 import com.my_medi.common.exception.ErrorStatus;
 import com.my_medi.common.exception.GeneralException;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,9 +26,9 @@ public class TestApiController {
         return dto;
     }
 
-    @GetMapping("/exceptions")
-    public void testException() {
-        throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
+    @GetMapping("/health-checkup")
+    public ApiResponseDto<String> healthCheckup() {
+        return ApiResponseDto.onSuccess(HttpStatus.OK.toString());
     }
 
 

--- a/src/main/java/com/my_medi/api/member/dto/RegisterMemberDto.java
+++ b/src/main/java/com/my_medi/api/member/dto/RegisterMemberDto.java
@@ -17,6 +17,8 @@ public class RegisterMemberDto {
     private String email;
     private String phoneNumber;
     private String profileImgUrl;
+    private String loginId;
+    private String password;
 
 
 }

--- a/src/main/java/com/my_medi/api/user/controller/UserApiController.java
+++ b/src/main/java/com/my_medi/api/user/controller/UserApiController.java
@@ -34,8 +34,8 @@ public class UserApiController {
 
     @Operation(summary = "사용자 계정을 생성합니다.")
     @PostMapping
-    public ApiResponseDto<Long> registerUserAccount(@RequestBody RegisterUserDto registerUserDto) {
-        return ApiResponseDto.onSuccess(userCommandService.registerUser(registerUserDto));
+    public ApiResponseDto<Long> registerUserAccount(@RequestBody RegisterMemberDto registerMemberDto) {
+        return ApiResponseDto.onSuccess(userCommandService.registerUser(registerMemberDto));
     }
 
     //TODO 계정 수정

--- a/src/main/java/com/my_medi/api/user/dto/RegisterUserDto.java
+++ b/src/main/java/com/my_medi/api/user/dto/RegisterUserDto.java
@@ -12,6 +12,4 @@ public class RegisterUserDto {
     private RegisterMemberDto member;
 
     // User 정보
-    private Float height;
-    private Float weight;
 }

--- a/src/main/java/com/my_medi/domain/expert/service/ExpertCommandServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/expert/service/ExpertCommandServiceImpl.java
@@ -11,6 +11,7 @@ import com.my_medi.domain.member.entity.Role;
 import com.my_medi.domain.user.entity.User;
 import com.my_medi.domain.user.exception.UserHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,11 +22,11 @@ import java.util.UUID;
 @Service
 public class ExpertCommandServiceImpl implements ExpertCommandService {
     private final ExpertRepository expertRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public Long registerExpert(RegisterExpertDto registerExpertDto) {
 
-        //TODO [LATER] requestDto에 맞게 argument 변경해주기
         Expert expert = Expert.builder()
                 //member
                 .name(registerExpertDto.getMember().getName())
@@ -36,6 +37,8 @@ public class ExpertCommandServiceImpl implements ExpertCommandService {
                 .phoneNumber(registerExpertDto.getMember().getPhoneNumber())
                 .profileImgUrl(registerExpertDto.getMember().getProfileImgUrl())
                 .role(Role.EXPERT) //role은 입력 x, EXPERT로 고정
+                .loginId(registerExpertDto.getMember().getLoginId())
+                .password(passwordEncoder.encode(registerExpertDto.getMember().getPassword()))
                 //Expert
                 .specialty(registerExpertDto.getSpecialty())
                 .organizationName(registerExpertDto.getOrganizationName())

--- a/src/main/java/com/my_medi/domain/member/entity/Member.java
+++ b/src/main/java/com/my_medi/domain/member/entity/Member.java
@@ -60,8 +60,11 @@ public abstract class Member extends BaseTimeEntity implements UserDetails {
 
     //이메일
     // TODO: email, password : 검증 어노테이션, presentation(web 혹은 api) 레이어에 좀 더 적합하므로 추후 수정
-    @Column(name = "email", nullable = false)
+    @Column(name = "email", nullable = false, unique = true)
     private String email;
+
+    @Column(name = "login_id", unique = true)
+    private String loginId;
 
     //연락처
     @Column(name = "phone_number", nullable = false)

--- a/src/main/java/com/my_medi/domain/member/entity/Member.java
+++ b/src/main/java/com/my_medi/domain/member/entity/Member.java
@@ -66,6 +66,8 @@ public abstract class Member extends BaseTimeEntity implements UserDetails {
     @Column(name = "login_id", unique = true)
     private String loginId;
 
+    private String password;
+
     //연락처
     @Column(name = "phone_number", nullable = false)
     private String phoneNumber;
@@ -100,7 +102,7 @@ public abstract class Member extends BaseTimeEntity implements UserDetails {
     }
     @Override
     public String getPassword() {
-        return null;
+        return this.password;
     }
 
     @Override

--- a/src/main/java/com/my_medi/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/my_medi/domain/member/repository/MemberRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member,Long> {
     Optional<Member> findByUsername(String username);
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByLoginId(String loginId);
 }

--- a/src/main/java/com/my_medi/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/my_medi/domain/member/service/MemberQueryService.java
@@ -5,4 +5,6 @@ import com.my_medi.domain.member.entity.Member;
 public interface MemberQueryService {
     Member getMemberByUsername(String username);
     Member getByKakaoEmail(String email);
+
+    Member getByLoginId(String loginId);
 }

--- a/src/main/java/com/my_medi/domain/member/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/member/service/MemberQueryServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberQueryServiceImpl implements MemberQueryService{
     private final MemberRepository memberRepository;
 
+    //TODO member handler 새로 생성하기
     @Override
     public Member getMemberByUsername(String username) {
         return memberRepository.findByUsername(username)
@@ -25,6 +26,12 @@ public class MemberQueryServiceImpl implements MemberQueryService{
     public Member getByKakaoEmail(String email) {
         return memberRepository.findByEmail(email)
                 .orElseThrow(() -> ExpertHandler.NOT_FOUND);
+    }
+
+    @Override
+    public Member getByLoginId(String loginId) {
+        return memberRepository.findByLoginId(loginId)
+                .orElseThrow(()->ExpertHandler.NOT_FOUND);
     }
 }
 

--- a/src/main/java/com/my_medi/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/my_medi/domain/user/service/UserCommandService.java
@@ -6,8 +6,7 @@ import com.my_medi.domain.user.dto.UpdateUserDto;
 
 public interface UserCommandService {
 
-    //TODO [LATER] requestDto에 맞게 argument 변경해주기
-    Long registerUser(RegisterUserDto registerUserDto);
+    Long registerUser(RegisterMemberDto registerMemberDto);
 
     //TODO [Now] 변경할 값들 argument로 받아오기 : dto 직접 생성
     Long updateUserInformation(Long userId, UpdateUserDto updateUserDto);

--- a/src/main/java/com/my_medi/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/user/service/UserCommandServiceImpl.java
@@ -1,7 +1,6 @@
 package com.my_medi.domain.user.service;
 import com.my_medi.api.member.dto.RegisterMemberDto;
-import com.my_medi.api.user.dto.RegisterUserDto;
-import com.my_medi.domain.expert.entity.Expert;
+
 import com.my_medi.domain.member.entity.Role;
 import com.my_medi.domain.user.dto.UpdateUserDto;
 import com.my_medi.domain.user.entity.User;
@@ -9,6 +8,7 @@ import com.my_medi.domain.user.repository.UserRepository;
 import com.my_medi.domain.user.exception.UserHandler;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -19,21 +19,22 @@ import java.util.UUID;
 public class UserCommandServiceImpl implements UserCommandService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
-    public Long registerUser(RegisterUserDto registerUserDto){
+    public Long registerUser(RegisterMemberDto registerMemberDto){
         //TODO [LATER] requestDto에 맞게 구현예정
         User user = User.builder()
-                .name(registerUserDto.getMember().getName())
-                .birthDate(registerUserDto.getMember().getBirthDate())
-                .gender(registerUserDto.getMember().getGender())
+                .name(registerMemberDto.getName())
+                .birthDate(registerMemberDto.getBirthDate())
+                .gender(registerMemberDto.getGender())
                 .username(UUID.randomUUID().toString())
-                .email(registerUserDto.getMember().getEmail())
-                .phoneNumber(registerUserDto.getMember().getPhoneNumber())
-                .profileImgUrl(registerUserDto.getMember().getProfileImgUrl())
+                .email(registerMemberDto.getEmail())
+                .phoneNumber(registerMemberDto.getPhoneNumber())
+                .profileImgUrl(registerMemberDto.getProfileImgUrl())
                 .role(Role.USER)
-                .height(registerUserDto.getHeight())
-                .weight(registerUserDto.getWeight())
+                .loginId(registerMemberDto.getLoginId())
+                .password(passwordEncoder.encode(registerMemberDto.getPassword()))
                 .build();
         return userRepository.save(user).getId();
     }

--- a/src/main/java/com/my_medi/security/config/PasswordConfig.java
+++ b/src/main/java/com/my_medi/security/config/PasswordConfig.java
@@ -1,0 +1,15 @@
+package com.my_medi.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        // BCrypt Encoder 사용
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/src/main/java/com/my_medi/security/config/SecurityConfig.java
+++ b/src/main/java/com/my_medi/security/config/SecurityConfig.java
@@ -85,7 +85,7 @@ public class SecurityConfig {
         return new String[]{
                 "/api/v1/tokens/login",
                 "/api/v1/test",
-                "/api/v1/test/exceptions",
+                "/api/v1/test/health-checkup",
                 "/api/v1/examples/user",
                 "/api/v1/examples/global"
         };

--- a/src/main/java/com/my_medi/security/config/SecurityConfig.java
+++ b/src/main/java/com/my_medi/security/config/SecurityConfig.java
@@ -83,7 +83,7 @@ public class SecurityConfig {
     //[GET] 인증 없이 접근 허용할 경로 목록
     private String[] permitAllGetPaths() {
         return new String[]{
-                "/api/v1/tokens/login",
+
                 "/api/v1/test",
                 "/api/v1/test/health-checkup",
                 "/api/v1/examples/user",
@@ -94,6 +94,7 @@ public class SecurityConfig {
     //[POST] 인증 없이 접근 허용할 경로 목록
     private String[] permitAllPostPaths() {
         return new String[]{
+                "/api/v1/tokens/login",
                 "/api/v1/tokens/reissue",
                 "/api/v1/users",
                 "/api/v1/experts",

--- a/src/main/java/com/my_medi/security/controller/TokenApiController.java
+++ b/src/main/java/com/my_medi/security/controller/TokenApiController.java
@@ -2,6 +2,7 @@ package com.my_medi.security.controller;
 
 import com.my_medi.api.common.dto.ApiResponseDto;
 import com.my_medi.security.jwt.dto.JwtToken;
+import com.my_medi.security.jwt.dto.MemberLoginRequestDto;
 import com.my_medi.security.jwt.service.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -18,9 +19,9 @@ public class TokenApiController {
     private final TokenService tokenService;
 
     @Operation(summary = "[TEST용] 이메일로 JWT 토큰 발급")
-    @GetMapping("/login")
-    public ApiResponseDto<JwtToken> login(@RequestParam String kakaoEmail) {
-        return ApiResponseDto.onSuccess(tokenService.login(kakaoEmail));
+    @PostMapping("/login")
+    public ApiResponseDto<JwtToken> login(@RequestBody MemberLoginRequestDto memberLoginRequestDto) {
+        return ApiResponseDto.onSuccess(tokenService.login(memberLoginRequestDto));
     }
 
     @Operation(summary = "토큰 재발급", description = "Refresh Token으로 Access Token 재발급합니다.")

--- a/src/main/java/com/my_medi/security/controller/TokenApiController.java
+++ b/src/main/java/com/my_medi/security/controller/TokenApiController.java
@@ -8,8 +8,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @Tag(name = "Token API", description = "JWT 토큰 관련 API")
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/com/my_medi/security/exception/JwtAuthenticationException.java
+++ b/src/main/java/com/my_medi/security/exception/JwtAuthenticationException.java
@@ -9,6 +9,9 @@ public class JwtAuthenticationException extends AuthenticationException {
             = new JwtAuthenticationException(SecurityErrorStatus.AUTH_UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR);
     public static final AuthenticationException ASSIGNABLE_PARAMETER
             = new JwtAuthenticationException(SecurityErrorStatus.AUTH_ASSIGNABLE_PARAMETER);
+
+    public static final AuthenticationException WRONG_PASSWORD
+            = new JwtAuthenticationException(SecurityErrorStatus.AUTH_WRONG_PASSWORD);
     public JwtAuthenticationException(SecurityErrorStatus errorStatus) {
         super(errorStatus.name());
     }

--- a/src/main/java/com/my_medi/security/exception/SecurityErrorStatus.java
+++ b/src/main/java/com/my_medi/security/exception/SecurityErrorStatus.java
@@ -25,7 +25,8 @@ public enum SecurityErrorStatus implements BaseErrorCode {
     AUTH_ROLE_CANNOT_EXECUTE_URI(HttpStatus.BAD_REQUEST, 4357, "해당 권한으로는 요청을 처리할 수 없습니다."),
     AUTH_UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR(HttpStatus.BAD_REQUEST, 4358, "로그인이 필요없는 API입니다."),
     AUTH_ASSIGNABLE_PARAMETER(HttpStatus.BAD_REQUEST, 4359, "인증타입이 잘못되어 할당이 불가능합니다."),
-    AUTH_INVALID_ROLE(HttpStatus.FORBIDDEN, 4360, "유효하지 않은 역할(Role)입니다.");
+    AUTH_INVALID_ROLE(HttpStatus.FORBIDDEN, 4360, "유효하지 않은 역할(Role)입니다."),
+    AUTH_WRONG_PASSWORD(HttpStatus.BAD_REQUEST, 4361, "패스워드가 잘못되었습니다." );
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/my_medi/security/jwt/dto/JwtToken.java
+++ b/src/main/java/com/my_medi/security/jwt/dto/JwtToken.java
@@ -1,5 +1,6 @@
 package com.my_medi.security.jwt.dto;
 
+import com.my_medi.domain.member.entity.Role;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,4 +18,5 @@ public class JwtToken {
     private String refreshToken;
     private Date accessTokenExpire;
     private Date refreshTokenExpire;
+    private String role;
 }

--- a/src/main/java/com/my_medi/security/jwt/dto/MemberLoginRequestDto.java
+++ b/src/main/java/com/my_medi/security/jwt/dto/MemberLoginRequestDto.java
@@ -1,0 +1,12 @@
+package com.my_medi.security.jwt.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MemberLoginRequestDto {
+
+    private String loginId;
+    private String password;
+}

--- a/src/main/java/com/my_medi/security/jwt/service/TokenService.java
+++ b/src/main/java/com/my_medi/security/jwt/service/TokenService.java
@@ -1,13 +1,14 @@
 package com.my_medi.security.jwt.service;
 
 import com.my_medi.security.jwt.dto.JwtToken;
+import com.my_medi.security.jwt.dto.MemberLoginRequestDto;
 import org.springframework.security.core.Authentication;
 
 import java.util.Date;
 
 public interface TokenService {
 
-    JwtToken login(String kakaoEmail);
+    JwtToken login(MemberLoginRequestDto memberLoginRequestDto);
     JwtToken issueTokens(String refreshToken);
 
     JwtToken generateToken(Authentication authentication);

--- a/src/main/java/com/my_medi/security/jwt/service/TokenServiceImpl.java
+++ b/src/main/java/com/my_medi/security/jwt/service/TokenServiceImpl.java
@@ -54,7 +54,6 @@ public class TokenServiceImpl implements TokenService{
     @Override
     public JwtToken login(MemberLoginRequestDto memberLoginRequestDto) {
         Member member = memberQueryService.getByLoginId(memberLoginRequestDto.getLoginId());
-        log.info("password = {}", member.getPassword());
         if (!passwordEncoder.matches(memberLoginRequestDto.getPassword(), member.getPassword())) {
             //TODO security exception 아래와 같이 변경하기
             throw JwtAuthenticationException.WRONG_PASSWORD;

--- a/src/main/java/com/my_medi/security/jwt/service/TokenServiceImpl.java
+++ b/src/main/java/com/my_medi/security/jwt/service/TokenServiceImpl.java
@@ -54,7 +54,7 @@ public class TokenServiceImpl implements TokenService{
     @Override
     public JwtToken login(MemberLoginRequestDto memberLoginRequestDto) {
         Member member = memberQueryService.getByLoginId(memberLoginRequestDto.getLoginId());
-
+        log.info("password = {}", member.getPassword());
         if (!passwordEncoder.matches(memberLoginRequestDto.getPassword(), member.getPassword())) {
             //TODO security exception 아래와 같이 변경하기
             throw JwtAuthenticationException.WRONG_PASSWORD;

--- a/src/main/java/com/my_medi/security/jwt/service/TokenServiceImpl.java
+++ b/src/main/java/com/my_medi/security/jwt/service/TokenServiceImpl.java
@@ -121,6 +121,7 @@ public class TokenServiceImpl implements TokenService{
                 .refreshToken(refreshToken)
                 .accessTokenExpire(parseExpiration(accessToken))
                 .refreshTokenExpire(parseExpiration(refreshToken))
+                .role(authentication.getAuthorities().toString())
                 .build();
     }
 

--- a/src/main/resources/application-deploy.yml
+++ b/src/main/resources/application-deploy.yml
@@ -16,10 +16,10 @@ spring:
   ### SQL INIT for Batch ###
   sql:
     init:
-      mode: never
+      mode: ${SQL_INIT}
       schema-locations: classpath:db/schema-batch.sql
   ### BATCH ###
   batch:
     jdbc:
-      initialize-schema: never
+      initialize-schema: always
     platform: mysql


### PR DESCRIPTION
## #️⃣ 요약 설명
> health_checkup api 추가 및 login 시 사용될 값들 변경
## 📝 작업 내용

- 계정 등록 시 사용자, 전문가의 패스워드에는 PasswordEncoder를 통해 패스워드 인코딩
- 로그인 시, 로그인 요청 패스워드와 데이터베이스의 패스워드 비교
- 로그인 완료 후, 프론트에서 페이지를 [사용자]와 [전문가]를 구별하기 위한 role value 추가

```java
@Override
    public JwtToken login(MemberLoginRequestDto memberLoginRequestDto) {
        Member member = memberQueryService.getByLoginId(memberLoginRequestDto.getLoginId());
        log.info("password = {}", member.getPassword());
        if (!passwordEncoder.matches(memberLoginRequestDto.getPassword(), member.getPassword())) {
            //TODO security exception 아래와 같이 변경하기
            throw JwtAuthenticationException.WRONG_PASSWORD;
        }
        Authentication authentication = new UsernamePasswordAuthenticationToken(member, "",
                member.getAuthorities());
        return generateToken(authentication);
    }
```
데이터베이스 입력 결과(비밀번호)
> {bcrypt}$2a$10$R1eq/9LjKDBX8ISdUhmp4edfO/lg35oRnW.RiDMFe2fuKVihEaKsm

## 동작 확인

<img width="1470" height="324" alt="스크린샷 2025-07-30 오후 4 22 04" src="https://github.com/user-attachments/assets/6504263a-59f8-47d9-aad6-f318cab58eff" />
<img width="1574" height="406" alt="스크린샷 2025-07-30 오후 4 21 10" src="https://github.com/user-attachments/assets/eccf267c-8a9e-4182-b665-d8b5f8747a2e" />


## 💬 리뷰 요구사항(선택)

x