### PR TITLE
[MEDI-76] refactoring expert schedule

### DIFF
--- a/src/main/java/com/my_medi/api/schedule/controller/ExpertScheduleApiController.java
+++ b/src/main/java/com/my_medi/api/schedule/controller/ExpertScheduleApiController.java
@@ -13,11 +13,16 @@ import com.my_medi.domain.schedule.service.ScheduleCommandService;
 import com.my_medi.domain.schedule.service.ScheduleQueryService;
 import com.my_medi.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Tag(name = "[전문가 페이지] 스케줄 API")
 @RestController
@@ -62,15 +67,32 @@ public class ExpertScheduleApiController {
 
     @Operation(summary = "전문가의 가장 임박한 3개의 스케줄을 조회합니다.")
     @GetMapping("/upcoming")
-    public ApiResponseDto<List<ScheduleResponseDto.ScheduleSummaryDto>> getUpcomingSchedules(
+    public ApiResponseDto<List<ScheduleResponseDto.ScheduleDetailDto>> getUpcomingSchedules(
             @AuthExpert Expert expert) {
 
         List<Schedule> upcomingSchedules = scheduleQueryService.getUpcomingSchedulesForExpert(expert.getId());
 
-        List<ScheduleResponseDto.ScheduleSummaryDto> dtoList =
+        List<ScheduleResponseDto.ScheduleDetailDto> dtoList =
                 upcomingSchedules.stream()
-                        .map(ScheduleMapper::toScheduleSummaryDto)
+                        .map(ScheduleMapper::toScheduleDetailDto)
                         .toList();
+
+        return ApiResponseDto.onSuccess(dtoList);
+    }
+
+    @Operation(summary = "특정 날짜의 전문가 일정 목록을 조회합니다")
+    @GetMapping("/date")
+    public ApiResponseDto<List<ScheduleResponseDto.ScheduleDetailDto>> getSchedulesByDate(
+            @AuthExpert Expert expert,
+            @Parameter(description = "조회할 날짜 (형식: YYYY-MM-DD)", schema = @Schema(defaultValue = "YYYY-MM-DD"))
+
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        List<Schedule> schedules = scheduleQueryService.getSchedulesByExpertAndDate(expert.getId(), date);
+
+        List<ScheduleResponseDto.ScheduleDetailDto> dtoList = schedules.stream()
+                .map(ScheduleMapper::toScheduleDetailDto)
+                .collect(Collectors.toList());
 
         return ApiResponseDto.onSuccess(dtoList);
     }

--- a/src/main/java/com/my_medi/api/schedule/dto/EditScheduleDto.java
+++ b/src/main/java/com/my_medi/api/schedule/dto/EditScheduleDto.java
@@ -12,7 +12,7 @@ public class EditScheduleDto {
     private String memo;
     private String location;
 
-    private LocalDate date;
+    private LocalDate meetingDate;
     private int hour;
     private int minute;
     private boolean isAm;

--- a/src/main/java/com/my_medi/api/schedule/dto/EditScheduleDto.java
+++ b/src/main/java/com/my_medi/api/schedule/dto/EditScheduleDto.java
@@ -3,15 +3,17 @@ package com.my_medi.api.schedule.dto;
 import lombok.Builder;
 import lombok.Data;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Data
 @Builder
 
 public class EditScheduleDto {
-    private String title;
-    private String description;
-    private LocalDateTime startTime;
-    private LocalDateTime endTime;
+    private String memo;
     private String location;
+
+    private LocalDate date;
+    private int hour;
+    private int minute;
+    private boolean isAm;
 }

--- a/src/main/java/com/my_medi/api/schedule/dto/RegisterScheduleDto.java
+++ b/src/main/java/com/my_medi/api/schedule/dto/RegisterScheduleDto.java
@@ -14,7 +14,7 @@ public class RegisterScheduleDto {
     private String title;
     private String memo;
     private String location;
-    private LocalDate date;
+    private LocalDate meetingDate;
     private int hour;
     private int minute;
     private boolean isAm;

--- a/src/main/java/com/my_medi/api/schedule/dto/RegisterScheduleDto.java
+++ b/src/main/java/com/my_medi/api/schedule/dto/RegisterScheduleDto.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Data
@@ -11,8 +12,10 @@ import java.time.LocalDateTime;
 public class RegisterScheduleDto {
 
     private String title;
-    private String description;
-    private LocalDateTime startTime;
-    private LocalDateTime endTime;
+    private String memo;
     private String location;
+    private LocalDate date;
+    private int hour;
+    private int minute;
+    private boolean isAm;
 }

--- a/src/main/java/com/my_medi/api/schedule/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/my_medi/api/schedule/dto/ScheduleResponseDto.java
@@ -14,7 +14,7 @@ public class ScheduleResponseDto {
     public static class ScheduleSummaryDto{
         private Long id;
         private String title;
-        private LocalDate date;
+        private LocalDate meetingDate;
 
     }
 
@@ -25,7 +25,7 @@ public class ScheduleResponseDto {
         private String title;
         private String memo;
         private String location;
-        private LocalDate date;
+        private LocalDate meetingDate;
         private int hour;
         private int minute;
         private boolean isAm;

--- a/src/main/java/com/my_medi/api/schedule/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/my_medi/api/schedule/dto/ScheduleResponseDto.java
@@ -3,6 +3,7 @@ package com.my_medi.api.schedule.dto;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -13,8 +14,21 @@ public class ScheduleResponseDto {
     public static class ScheduleSummaryDto{
         private Long id;
         private String title;
-        private LocalDateTime startTime;
-        private LocalDateTime endTime;
+        private LocalDate date;
+
+    }
+
+    @Data
+    @Builder
+    public static class ScheduleDetailDto{
+        private Long id;
+        private String title;
+        private String memo;
+        private String location;
+        private LocalDate date;
+        private int hour;
+        private int minute;
+        private boolean isAm;
 
     }
 
@@ -22,5 +36,11 @@ public class ScheduleResponseDto {
     @Builder
     public static class ScheduleListDto{
         private List<ScheduleSummaryDto> scheduleSummaryDto;
+    }
+
+    @Data
+    @Builder
+    public static class ScheduleDetailListDto{
+        private List<ScheduleDetailDto> scheduleDetailDto;
     }
 }

--- a/src/main/java/com/my_medi/api/schedule/mapper/ScheduleMapper.java
+++ b/src/main/java/com/my_medi/api/schedule/mapper/ScheduleMapper.java
@@ -16,7 +16,7 @@ public class ScheduleMapper {
         return ScheduleSummaryDto.builder()
                 .id(schedule.getId())
                 .title(schedule.getTitle())
-                .date(schedule.getDate())
+                .meetingDate(schedule.getMeetingDate())
                 .build();
     }
 
@@ -24,9 +24,10 @@ public class ScheduleMapper {
         return ScheduleDetailDto.builder()
                 .id(schedule.getId())
                 .title(schedule.getTitle())
+                //TODO : title template으로 바꾸기 및 엔티티 내의 title 필드 제거
                 .memo(schedule.getMemo())
                 .location(schedule.getLocation())
-                .date(schedule.getDate())
+                .meetingDate(schedule.getMeetingDate())
                 .hour(schedule.getHour())
                 .minute(schedule.getMinute())
                 .isAm(schedule.isAm())

--- a/src/main/java/com/my_medi/api/schedule/mapper/ScheduleMapper.java
+++ b/src/main/java/com/my_medi/api/schedule/mapper/ScheduleMapper.java
@@ -1,6 +1,8 @@
 package com.my_medi.api.schedule.mapper;
 
 import com.my_medi.api.schedule.dto.ScheduleResponseDto;
+import com.my_medi.api.schedule.dto.ScheduleResponseDto.ScheduleDetailDto;
+import com.my_medi.api.schedule.dto.ScheduleResponseDto.ScheduleDetailListDto;
 import com.my_medi.api.schedule.dto.ScheduleResponseDto.ScheduleListDto;
 import com.my_medi.api.schedule.dto.ScheduleResponseDto.ScheduleSummaryDto;
 import com.my_medi.domain.schedule.entity.Schedule;
@@ -14,8 +16,20 @@ public class ScheduleMapper {
         return ScheduleSummaryDto.builder()
                 .id(schedule.getId())
                 .title(schedule.getTitle())
-                .startTime(schedule.getStartTime())
-                .endTime(schedule.getEndTime())
+                .date(schedule.getDate())
+                .build();
+    }
+
+    public static ScheduleDetailDto toScheduleDetailDto(Schedule schedule) {
+        return ScheduleDetailDto.builder()
+                .id(schedule.getId())
+                .title(schedule.getTitle())
+                .memo(schedule.getMemo())
+                .location(schedule.getLocation())
+                .date(schedule.getDate())
+                .hour(schedule.getHour())
+                .minute(schedule.getMinute())
+                .isAm(schedule.isAm())
                 .build();
     }
 
@@ -28,5 +42,14 @@ public class ScheduleMapper {
                 .scheduleSummaryDto(summaryList)
                 .build();
     }
-}
 
+    public static ScheduleDetailListDto toScheduleDetailListDto(List<Schedule> schedules) {
+        List<ScheduleDetailDto> detailList = schedules.stream()
+                .map(ScheduleMapper::toScheduleDetailDto)
+                .collect(Collectors.toList());
+
+        return ScheduleDetailListDto.builder()
+                .scheduleDetailDto(detailList)
+                .build();
+    }
+}

--- a/src/main/java/com/my_medi/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/my_medi/domain/schedule/entity/Schedule.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -34,18 +35,21 @@ public class Schedule extends BaseTimeEntity {
     private String title;
 
     @Column(columnDefinition = "TEXT")
-    private String description;
+    private String memo;
 
-    private LocalDateTime startTime;
-    private LocalDateTime endTime;
+    private LocalDate date;
+    private int hour;
+    private int minute;
+    private boolean isAm;
     private String location;
 
     public void update(EditScheduleDto dto) {
-        this.title = dto.getTitle();
-        this.description = dto.getDescription();
-        this.startTime = dto.getStartTime();
-        this.endTime = dto.getEndTime();
+        this.memo = dto.getMemo();
         this.location = dto.getLocation();
+        this.date = dto.getDate();
+        this.hour = dto.getHour();
+        this.minute = dto.getMinute();
+        this.isAm = dto.isAm();
     }
 
 

--- a/src/main/java/com/my_medi/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/my_medi/domain/schedule/entity/Schedule.java
@@ -37,7 +37,7 @@ public class Schedule extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private String memo;
 
-    private LocalDate date;
+    private LocalDate meetingDate;
     private int hour;
     private int minute;
     private boolean isAm;
@@ -46,7 +46,7 @@ public class Schedule extends BaseTimeEntity {
     public void update(EditScheduleDto dto) {
         this.memo = dto.getMemo();
         this.location = dto.getLocation();
-        this.date = dto.getDate();
+        this.meetingDate = dto.getMeetingDate();
         this.hour = dto.getHour();
         this.minute = dto.getMinute();
         this.isAm = dto.isAm();

--- a/src/main/java/com/my_medi/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/my_medi/domain/schedule/repository/ScheduleRepository.java
@@ -3,6 +3,7 @@ package com.my_medi.domain.schedule.repository;
 import com.my_medi.domain.schedule.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -12,13 +13,15 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     List<Schedule> findByExpertId(Long expertId);
 
-    List<Schedule> findByExpertIdAndStartTimeBetween(Long expertId, LocalDateTime start, LocalDateTime end);
+    List<Schedule> findByExpertIdAndDateBetween(Long expertId, LocalDate startDate, LocalDate endDate);
 
-    List<Schedule> findByUserIdAndStartTimeBetween(Long userId, LocalDateTime start, LocalDateTime end);
+    List<Schedule> findByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
 
-    List<Schedule> findTop3ByExpertIdAndStartTimeAfterOrderByStartTimeAsc(Long expertId, LocalDateTime now);
+    List<Schedule> findTop3ByExpertIdAndDateAfterOrderByDateAscHourAscMinuteAsc(Long expertId, LocalDate now);
 
-    List<Schedule> findTop3ByUserIdAndStartTimeAfterOrderByStartTimeAsc(Long userId, LocalDateTime now);
+    List<Schedule> findTop3ByUserIdAndDateAfterOrderByDateAscHourAscMinuteAsc(Long userId, LocalDate now);
+
+    List<Schedule> findAllByExpertIdAndDate(Long expertId, LocalDate date);
 
 
 

--- a/src/main/java/com/my_medi/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/my_medi/domain/schedule/repository/ScheduleRepository.java
@@ -2,9 +2,11 @@ package com.my_medi.domain.schedule.repository;
 
 import com.my_medi.domain.schedule.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import org.springframework.data.domain.Pageable;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
@@ -13,16 +15,33 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     List<Schedule> findByExpertId(Long expertId);
 
-    List<Schedule> findByExpertIdAndDateBetween(Long expertId, LocalDate startDate, LocalDate endDate);
+    List<Schedule> findByExpertIdAndMeetingDateBetween(Long expertId, LocalDate startDate, LocalDate endDate);
 
-    List<Schedule> findByUserIdAndDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
+    List<Schedule> findByUserIdAndMeetingDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
 
-    List<Schedule> findTop3ByExpertIdAndDateAfterOrderByDateAscHourAscMinuteAsc(Long expertId, LocalDate now);
+    @Query("""
+                SELECT s FROM Schedule s
+                WHERE s.expert.id = :expertId AND s.meetingDate > :now
+                ORDER BY s.meetingDate ASC, s.hour ASC, s.minute ASC
+            """)
+    List<Schedule> findUpcomingSchedulesByExpert(
+            @Param("expertId") Long expertId,
+            @Param("now") LocalDate now,
+            Pageable pageable
+    );
 
-    List<Schedule> findTop3ByUserIdAndDateAfterOrderByDateAscHourAscMinuteAsc(Long userId, LocalDate now);
+    @Query("""
+    SELECT s FROM Schedule s
+    WHERE s.user.id = :userId AND s.meetingDate > :now
+    ORDER BY s.meetingDate ASC, s.hour ASC, s.minute ASC
+""")
+    List<Schedule> findUpcomingSchedulesByUser(
+            @Param("userId") Long userId,
+            @Param("now") LocalDate now,
+            Pageable pageable
+    );
 
-    List<Schedule> findAllByExpertIdAndDate(Long expertId, LocalDate date);
 
-
-
+    List<Schedule> findAllByExpertIdAndMeetingDate(Long expertId, LocalDate meetingDate);
 }
+

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleCommandServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleCommandServiceImpl.java
@@ -51,7 +51,6 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
                 .hour(registerScheduleDto.getHour())
                 .minute(registerScheduleDto.getMinute())
                 .isAm(registerScheduleDto.isAm())
-                .location(registerScheduleDto.getLocation())
                 .memo(registerScheduleDto.getMemo())
                 .build();
 

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleCommandServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleCommandServiceImpl.java
@@ -47,7 +47,7 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
                 .user(user)
                 .title(registerScheduleDto.getTitle())
                 .location(registerScheduleDto.getLocation())
-                .date(registerScheduleDto.getDate())
+                .meetingDate(registerScheduleDto.getMeetingDate())
                 .hour(registerScheduleDto.getHour())
                 .minute(registerScheduleDto.getMinute())
                 .isAm(registerScheduleDto.isAm())

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleCommandServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleCommandServiceImpl.java
@@ -46,10 +46,13 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
                 .expert(expert)
                 .user(user)
                 .title(registerScheduleDto.getTitle())
-                .description(registerScheduleDto.getDescription())
-                .startTime(registerScheduleDto.getStartTime())
-                .endTime(registerScheduleDto.getEndTime())
                 .location(registerScheduleDto.getLocation())
+                .date(registerScheduleDto.getDate())
+                .hour(registerScheduleDto.getHour())
+                .minute(registerScheduleDto.getMinute())
+                .isAm(registerScheduleDto.isAm())
+                .location(registerScheduleDto.getLocation())
+                .memo(registerScheduleDto.getMemo())
                 .build();
 
         return scheduleRepository.save(schedule).getId();

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryService.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryService.java
@@ -3,6 +3,7 @@ package com.my_medi.domain.schedule.service;
 import com.my_medi.api.schedule.dto.RegisterScheduleDto;
 import com.my_medi.domain.schedule.entity.Schedule;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ScheduleQueryService {
@@ -18,6 +19,9 @@ public interface ScheduleQueryService {
     List<Schedule> getUpcomingSchedulesForUser(Long userId);
 
     List<Schedule> getUpcomingSchedulesForExpert(Long expertId);
+
+    List<Schedule> getSchedulesByExpertAndDate(Long expertId, LocalDate date);
+
 
 
 

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryServiceImpl.java
@@ -35,10 +35,7 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
         LocalDate startDate = LocalDate.of(year, month, 1);
         LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
 
-        LocalDateTime start = startDate.atStartOfDay();
-        LocalDateTime end = endDate.atTime(23, 59, 59);
-
-        return scheduleRepository.findByExpertIdAndStartTimeBetween(expertId, start, end);
+        return scheduleRepository.findByExpertIdAndDateBetween(expertId, startDate, endDate);
     }
 
     @Override
@@ -46,19 +43,15 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
         LocalDate startDate = LocalDate.of(year, month, 1);
         LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
 
-        LocalDateTime start = startDate.atStartOfDay();
-        LocalDateTime end = endDate.atTime(23, 59, 59);
-
-        return scheduleRepository.findByUserIdAndStartTimeBetween(userId, start, end);
+        return scheduleRepository.findByUserIdAndDateBetween(userId, startDate, endDate);
     }
 
-
     private List<Schedule> findUpcomingSchedules(SortType type, Long id) {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDate now = LocalDate.now();
 
         return switch (type) {
-            case USER -> scheduleRepository.findTop3ByUserIdAndStartTimeAfterOrderByStartTimeAsc(id, now);
-            case EXPERT -> scheduleRepository.findTop3ByExpertIdAndStartTimeAfterOrderByStartTimeAsc(id, now);
+            case USER -> scheduleRepository.findTop3ByUserIdAndDateAfterOrderByDateAscHourAscMinuteAsc(id, now);
+            case EXPERT -> scheduleRepository.findTop3ByExpertIdAndDateAfterOrderByDateAscHourAscMinuteAsc(id, now);
         };
     }
 
@@ -73,5 +66,10 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
     }
 
     public enum SortType { USER, EXPERT }
+
+    public List<Schedule> getSchedulesByExpertAndDate(Long expertId, LocalDate date) {
+        return scheduleRepository.findAllByExpertIdAndDate(expertId, date);
+    }
+
 
 }

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleQueryServiceImpl.java
@@ -8,8 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -35,7 +36,7 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
         LocalDate startDate = LocalDate.of(year, month, 1);
         LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
 
-        return scheduleRepository.findByExpertIdAndDateBetween(expertId, startDate, endDate);
+        return scheduleRepository.findByExpertIdAndMeetingDateBetween(expertId, startDate, endDate);
     }
 
     @Override
@@ -43,15 +44,16 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
         LocalDate startDate = LocalDate.of(year, month, 1);
         LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
 
-        return scheduleRepository.findByUserIdAndDateBetween(userId, startDate, endDate);
+        return scheduleRepository.findByUserIdAndMeetingDateBetween(userId, startDate, endDate);
     }
 
     private List<Schedule> findUpcomingSchedules(SortType type, Long id) {
         LocalDate now = LocalDate.now();
+        Pageable top3 = PageRequest.of(0, 3);
 
         return switch (type) {
-            case USER -> scheduleRepository.findTop3ByUserIdAndDateAfterOrderByDateAscHourAscMinuteAsc(id, now);
-            case EXPERT -> scheduleRepository.findTop3ByExpertIdAndDateAfterOrderByDateAscHourAscMinuteAsc(id, now);
+            case USER -> scheduleRepository.findUpcomingSchedulesByUser(id, now, top3);
+            case EXPERT -> scheduleRepository.findUpcomingSchedulesByExpert(id, now, top3);
         };
     }
 
@@ -67,8 +69,8 @@ public class ScheduleQueryServiceImpl implements ScheduleQueryService {
 
     public enum SortType { USER, EXPERT }
 
-    public List<Schedule> getSchedulesByExpertAndDate(Long expertId, LocalDate date) {
-        return scheduleRepository.findAllByExpertIdAndDate(expertId, date);
+    public List<Schedule> getSchedulesByExpertAndDate(Long expertId, LocalDate meetingDate) {
+        return scheduleRepository.findAllByExpertIdAndMeetingDate(expertId, meetingDate);
     }
 
 


### PR DESCRIPTION
## #️⃣ 요약 설명
전문가 스케줄 로직 변경

## 📝 작업 내용

> 피그마와 같게 dto 수정
endTime 삭제 및 관련 로직 수정
월별 조회 dto 수정 및 controller 수정

## 동작 확인

<img width="1470" height="956" alt="스크린샷 2025-08-02 오후 11 41 28" src="https://github.com/user-attachments/assets/91ac95a2-43b7-488f-8552-8f259115d50b" />

- 해당 날짜에 대한 스케줄 조회

<img width="1470" height="956" alt="스크린샷 2025-08-02 오후 11 40 44" src="https://github.com/user-attachments/assets/b2c21481-6465-4d33-82cc-1040fb584068" />

- 다가오는 일정 조회 
<img width="1470" height="956" alt="스크린샷 2025-08-02 오후 11 36 50" src="https://github.com/user-attachments/assets/f8f3a871-3c90-4e3b-bd24-8ebf95d0daae" />
- 해당 월에 대한 스케줄 조회

## 💬 리뷰 요구사항(선택)

다가오는 일정 조회는 저번에 3개여서 그거 유지하고 있습니다. 로직 바뀌었으면 알려주시기 바랍니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 전문가의 특정 날짜별 일정 조회가 가능한 새로운 API 엔드포인트가 추가되었습니다.

* **기능 개선**
  * 일정의 시간 정보가 기존 시작/종료 시각 대신 날짜, 시, 분, 오전/오후로 세분화되어 입력 및 조회됩니다.
  * 일정 설명(description) 필드가 메모(memo) 필드로 변경되었습니다.
  * 월별 및 다가오는 일정 조회 시 날짜 기반으로 더욱 직관적으로 일정을 확인할 수 있습니다.

* **버그 수정**
  * 없음

* **문서화**
  * 날짜 파라미터에 대한 Swagger 설명이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->