### PR TITLE
[MEDI-77] refactoring user consultation

### DIFF
--- a/src/main/java/com/my_medi/api/consultation/dto/UserConsultationDto.java
+++ b/src/main/java/com/my_medi/api/consultation/dto/UserConsultationDto.java
@@ -1,13 +1,23 @@
 package com.my_medi.api.consultation.dto;
 
 import com.my_medi.domain.consultationRequest.entity.RequestStatus;
+import com.my_medi.domain.expert.entity.Specialty;
 import lombok.Builder;
 import lombok.Data;
+
+import java.time.LocalDate;
 
 @Data
 @Builder
 public class UserConsultationDto {
-    private Long id;
-    private String comment;
+    private Long consultationId;
+    private Long expertId;
     private RequestStatus status;
+    private Specialty specialty;
+    private String name;
+    private String nickname;
+    private String profileImgUrl;
+    private String phoneNumber;
+    private String introSentence;
+    private LocalDate requestDate;
 }

--- a/src/main/java/com/my_medi/api/consultation/mapper/UserConsultationConvert.java
+++ b/src/main/java/com/my_medi/api/consultation/mapper/UserConsultationConvert.java
@@ -2,12 +2,8 @@ package com.my_medi.api.consultation.mapper;
 
 import com.my_medi.api.consultation.dto.UserConsultationDto;
 import com.my_medi.domain.consultationRequest.entity.ConsultationRequest;
-import com.my_medi.domain.consultationRequest.entity.RequestStatus;
 import com.my_medi.domain.expert.entity.Expert;
-import com.my_medi.domain.expert.entity.Specialty;
-import com.my_medi.domain.user.entity.User;
 
-import java.time.LocalDate;
 
 public class UserConsultationConvert {
     public static UserConsultationDto toDto(ConsultationRequest request) {

--- a/src/main/java/com/my_medi/api/consultation/mapper/UserConsultationConvert.java
+++ b/src/main/java/com/my_medi/api/consultation/mapper/UserConsultationConvert.java
@@ -2,13 +2,27 @@ package com.my_medi.api.consultation.mapper;
 
 import com.my_medi.api.consultation.dto.UserConsultationDto;
 import com.my_medi.domain.consultationRequest.entity.ConsultationRequest;
+import com.my_medi.domain.consultationRequest.entity.RequestStatus;
+import com.my_medi.domain.expert.entity.Expert;
+import com.my_medi.domain.expert.entity.Specialty;
+import com.my_medi.domain.user.entity.User;
+
+import java.time.LocalDate;
 
 public class UserConsultationConvert {
     public static UserConsultationDto toDto(ConsultationRequest request) {
+        Expert expert = request.getExpert();
         return UserConsultationDto.builder()
-                .id(request.getId())
-                .comment(request.getComment())
+                .consultationId(request.getId())
+                .expertId(expert.getId())
                 .status(request.getRequestStatus())
+                .specialty(expert.getSpecialty())
+                .name(expert.getName())
+                .nickname(expert.getNickname())
+                .profileImgUrl(expert.getProfileImgUrl())
+                .phoneNumber(expert.getPhoneNumber())
+                .introSentence(expert.getIntroSentence())
+                .requestDate(request.getCreatedDate().toLocalDate())
                 .build();
     }
 }

--- a/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
@@ -32,4 +32,7 @@ public interface ConsultationRequestRepository extends JpaRepository<Consultatio
 
     boolean existsByExpertIdAndUserIdAndRequestStatus(Long expertId, Long userId, RequestStatus requestStatus);
 
+    List<ConsultationRequest> findByUserIdAndExpertIdAndStatus(Long userId, Long expertId, RequestStatus status);
+
+
 }

--- a/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
@@ -32,7 +32,7 @@ public interface ConsultationRequestRepository extends JpaRepository<Consultatio
 
     boolean existsByExpertIdAndUserIdAndRequestStatus(Long expertId, Long userId, RequestStatus requestStatus);
 
-    List<ConsultationRequest> findByUserIdAndExpertIdAndStatus(Long userId, Long expertId, RequestStatus status);
+    List<ConsultationRequest> findByUserIdAndExpertIdAndRequestStatus(Long userId, Long expertId, RequestStatus requestStatus);
 
 
 }

--- a/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestCommandServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestCommandServiceImpl.java
@@ -85,6 +85,17 @@ public class ConsultationRequestCommandServiceImpl implements ConsultationReques
         ConsultationRequest request = getRequestedConsultation(consultationId);
         validateExpertApprovalOrRejectionAuthority(request, expert);
         request.approve();
+
+        Long userId = request.getUser().getId();
+        Long expertId = expert.getId();
+
+        List<ConsultationRequest> toDelete = consultationRequestRepository
+                .findByUserIdAndExpertIdAndStatus(userId, expertId, RequestStatus.REQUESTED)
+                .stream()
+                .filter(req -> !req.getId().equals(consultationId))
+                .toList();
+
+        consultationRequestRepository.deleteAllInBatch(toDelete);
     }
 
     @Override

--- a/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestCommandServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestCommandServiceImpl.java
@@ -90,7 +90,7 @@ public class ConsultationRequestCommandServiceImpl implements ConsultationReques
         Long expertId = expert.getId();
 
         List<ConsultationRequest> toDelete = consultationRequestRepository
-                .findByUserIdAndExpertIdAndStatus(userId, expertId, RequestStatus.REQUESTED)
+                .findByUserIdAndExpertIdAndRequestStatus(userId, expertId, RequestStatus.REQUESTED)
                 .stream()
                 .filter(req -> !req.getId().equals(consultationId))
                 .toList();

--- a/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestCommandServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestCommandServiceImpl.java
@@ -114,14 +114,13 @@ public class ConsultationRequestCommandServiceImpl implements ConsultationReques
     }
 
     private void deleteOtherRequestedConsultations(ConsultationRequest request) {
-        Long userId = request.getUser().getId();
-        Long expertId = request.getExpert().getId();
-        Long currentId = request.getId();
-
         List<ConsultationRequest> toDelete = consultationRequestRepository
-                .findByUserIdAndExpertIdAndRequestStatus(userId, expertId, RequestStatus.REQUESTED)
-                .stream()
-                .filter(req -> !req.getId().equals(currentId))
+                .findByUserIdAndExpertIdAndRequestStatus(
+                        request.getUser().getId(),
+                        request.getExpert().getId(),
+                        RequestStatus.REQUESTED
+                ).stream()
+                .filter(req -> !req.getId().equals(request.getId()))
                 .toList();
 
         consultationRequestRepository.deleteAllInBatch(toDelete);


### PR DESCRIPTION
## #️⃣ 요약 설명
유저 상담 관련 리팩토링

## 📝 작업 내용

> 피그마와 동일하게 dto 수정
상담 승인 혹은 거절 시 같은 REQUESTED 상태 요청은 하드 삭제하는 기능 추가
한 유저가 동일 전문가에게 여러 요청을 보냈을 경우, 중복된 REQUESTED 요청을 하나만 반환하도록 로직 구현


## 동작 확인

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/f6680994-0602-472b-b788-eb02052285ed" width="400"/></td>
    <td><img src="https://github.com/user-attachments/assets/14bfadab-4f20-4606-af74-0fcdb9839370" width="400"/></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/e51e059d-de54-45da-9525-2b873e5aa9b9" width="400"/></td>
    <td><img src="https://github.com/user-attachments/assets/bf1db2e2-8128-4395-a979-45022a31c63d" width="400"/></td>
  </tr>
</table>

- 승인 시 requested 삭제

<table>
  <tr>
    <td><img width="1470" height="956" alt="스크린샷 2025-08-04 오전 10 14 54" src="https://github.com/user-attachments/assets/fc6b30a1-26d3-40e3-ad7e-ed813b084fce" /></td>
    <td><img width="1470" height="956" alt="스크린샷 2025-08-04 오전 10 15 12" src="https://github.com/user-attachments/assets/2c25d0cd-7899-4e39-8978-84c78b5c5d0e" /></td>
  </tr>
  <tr>
    <td><img width="1470" height="956" alt="스크린샷 2025-08-04 오전 10 15 18" src="https://github.com/user-attachments/assets/2f403187-60d3-4b14-b30d-d7e64ac27ec9" /></td>
  </tr>
</table>

- 거절 시 삭제

<table>
  <tr>
    <td><img width="1470" height="956" alt="스크린샷 2025-08-04 오전 10 53 30" src="https://github.com/user-attachments/assets/d965c89c-11bb-4a9e-8311-b76f2a7d62b5" /></td>
    <td><img width="1470" height="956" alt="스크린샷 2025-08-04 오전 10 55 02" src="https://github.com/user-attachments/assets/9dd0da52-7400-4928-8e64-9a5f5f6177b3" /></td>
  </tr>
</table>

- requested 중복 시 첫번째 데이터를 보여주도록 구현

## 💬 리뷰 요구사항(선택)

Set<Expert>만 추출하면 ConsultationRequest와의 관계가 끊어진다고 하여 다른 방식으로 구현했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 내 상담 요청 목록에서 'REQUESTED' 상태일 때 전문가별로 중복된 요청이 제거되어 한 명의 전문가당 한 건만 표시됩니다.
  * 상담 요청 DTO에 전문가 정보(전문가 ID, 전문분야, 이름, 닉네임, 프로필 이미지, 전화번호, 소개 문장, 요청일자)가 추가되어 더 많은 정보를 확인할 수 있습니다.

* **버그 수정**
  * 상담 요청 승인 또는 거절 시 동일 사용자-전문가 조합의 다른 대기 중인 요청이 자동으로 삭제됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->