### PR TITLE
[MEDI-85] implement expert detail information for user

### DIFF
--- a/src/main/java/com/my_medi/api/consultation/controller/UserConsultationApiController.java
+++ b/src/main/java/com/my_medi/api/consultation/controller/UserConsultationApiController.java
@@ -81,11 +81,12 @@ public class UserConsultationApiController {
     }
 
     @Operation(summary = "상담 요청한 전문가의 상세 정보를 조회합니다.")
-    @GetMapping("/experts/{expertId}")
+    @GetMapping("/experts/{expertId}/requested")
     public ApiResponseDto<UserConsultationDto.ExpertRequestedDto> getExpertDetail(
+            @AuthUser User user,
             @PathVariable Long expertId
     ) {
-        ConsultationRequest request = consultationRequestQueryService.getRequestedExpertDetail(expertId);
+        ConsultationRequest request = consultationRequestQueryService.getRequestedExpertDetail(user.getId(), expertId);
         UserConsultationDto.ExpertRequestedDto detailDto = UserConsultationConvert.toDetailDto(request);
         return ApiResponseDto.onSuccess(detailDto);
     }

--- a/src/main/java/com/my_medi/api/consultation/controller/UserConsultationApiController.java
+++ b/src/main/java/com/my_medi/api/consultation/controller/UserConsultationApiController.java
@@ -4,20 +4,27 @@ import com.my_medi.api.common.dto.ApiResponseDto;
 import com.my_medi.api.consultation.dto.UserConsultationDto;
 import com.my_medi.api.consultation.mapper.UserConsultationConvert;
 import com.my_medi.api.consultation.service.ConsultationUseCase;
+import com.my_medi.api.consultation.validator.ExpertAllowedToViewUserInfoValidator;
 import com.my_medi.common.annotation.AuthUser;
 import com.my_medi.domain.consultationRequest.entity.ConsultationRequest;
 import com.my_medi.domain.consultationRequest.entity.RequestStatus;
+import com.my_medi.domain.consultationRequest.exception.ConsultationRequestHandler;
 import com.my_medi.domain.consultationRequest.repository.ConsultationRequestRepository;
 import com.my_medi.domain.consultationRequest.service.ConsultationRequestCommandService;
 import com.my_medi.domain.consultationRequest.service.ConsultationRequestQueryService;
+import com.my_medi.domain.expert.entity.Expert;
+import com.my_medi.domain.expert.exception.ExpertHandler;
+import com.my_medi.domain.expert.repository.ExpertRepository;
 import com.my_medi.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.*;
 
 
-
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,6 +38,10 @@ public class UserConsultationApiController {
     private final ConsultationUseCase consultationUseCase;
     private final ConsultationRequestQueryService consultationRequestQueryService;;
     private final ConsultationRequestRepository consultationRequestRepository;
+    private final ExpertRepository expertRepository;
+    private final ExpertAllowedToViewUserInfoValidator expertAllowedToViewUserInfoValidator;
+
+
 
     @Operation(summary = "전문가에게 상담요청을 보냅니다.")
     @PostMapping("/experts/{expertId}")
@@ -88,18 +99,34 @@ public class UserConsultationApiController {
             @AuthUser User user,
             @PathVariable Long expertId
     ) {
-        ConsultationRequest request = consultationRequestQueryService.getRequestedExpertDetail(user.getId(), expertId);
-
         int requestCount = consultationRequestRepository
                 .countByUserIdAndExpertIdAndRequestStatus(user.getId(), expertId, RequestStatus.REQUESTED);
 
+        if (requestCount == 0) {
+            throw ConsultationRequestHandler.NOT_FOUND;
+        }
+
+        PageRequest page = PageRequest.of(0, 1);
+
+        LocalDate requestedAt = consultationRequestRepository
+                .findLatestRequestedDates(user.getId(), expertId, RequestStatus.REQUESTED, page)
+                .stream()
+                .findFirst()
+                .map(LocalDateTime::toLocalDate)
+                .orElseThrow(() -> ConsultationRequestHandler.NOT_FOUND);
+
+        Expert expert = expertRepository.findById(expertId)
+                .orElseThrow(() -> ExpertHandler.NOT_FOUND);
+
         UserConsultationDto.ExpertRequestedDto dto =
-                UserConsultationConvert.toRequestedDetailDto(request, requestCount);
+                UserConsultationConvert.toRequestedDetailDto(
+                        expert,
+                        requestCount,
+                        requestedAt
+                );
 
         return ApiResponseDto.onSuccess(dto);
     }
-
-
 
     @Operation(summary = "매칭된 전문가의 상세 정보를 조회합니다.")
     @GetMapping("/experts/{expertId}/matched")
@@ -111,5 +138,7 @@ public class UserConsultationApiController {
         UserConsultationDto.ExpertAcceptedDto detailDto = UserConsultationConvert.toDetailDto(request);
         return ApiResponseDto.onSuccess(detailDto);
     }
+
+
 
 }

--- a/src/main/java/com/my_medi/api/consultation/controller/UserConsultationApiController.java
+++ b/src/main/java/com/my_medi/api/consultation/controller/UserConsultationApiController.java
@@ -40,7 +40,7 @@ public class UserConsultationApiController {
 
     @Operation(summary = "본인이 요청한 상담 목록을 조회합니다.")
     @GetMapping
-    public ApiResponseDto<List<UserConsultationDto>> getMyConsultations(
+    public ApiResponseDto<List<UserConsultationDto.UserConsultationStatusDto>> getMyConsultations(
             @AuthUser User user,
             @RequestParam(required = false) RequestStatus status
     ) {
@@ -61,12 +61,11 @@ public class UserConsultationApiController {
                     .toList();
         }
 
-        List<UserConsultationDto> dtoList = deduplicated.stream()
+        List<UserConsultationDto.UserConsultationStatusDto> dtoList = deduplicated.stream()
                 .map(UserConsultationConvert::toDto)
                 .toList();
 
         return ApiResponseDto.onSuccess(dtoList);
-
     }
 
 

--- a/src/main/java/com/my_medi/api/consultation/controller/UserConsultationApiController.java
+++ b/src/main/java/com/my_medi/api/consultation/controller/UserConsultationApiController.java
@@ -90,4 +90,15 @@ public class UserConsultationApiController {
         return ApiResponseDto.onSuccess(detailDto);
     }
 
+    @Operation(summary = "매칭된 전문가의 상세 정보를 조회합니다.")
+    @GetMapping("/experts/{expertId}/matched")
+    public ApiResponseDto<UserConsultationDto.ExpertRequestedDto> getMatchedExpertDetail(
+            @AuthUser User user,
+            @PathVariable Long expertId
+    ) {
+        ConsultationRequest request = consultationRequestQueryService.getMatchedExpertDetail(user.getId(), expertId);
+        UserConsultationDto.ExpertRequestedDto detailDto = UserConsultationConvert.toDetailDto(request);
+        return ApiResponseDto.onSuccess(detailDto);
+    }
+
 }

--- a/src/main/java/com/my_medi/api/consultation/controller/UserConsultationApiController.java
+++ b/src/main/java/com/my_medi/api/consultation/controller/UserConsultationApiController.java
@@ -15,6 +15,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -76,6 +78,16 @@ public class UserConsultationApiController {
                                                    @PathVariable Long consultationId) {
         consultationRequestCommandService.cancelRequest(consultationId, user.getId());
         return ApiResponseDto.onSuccess(consultationId);
+    }
+
+    @Operation(summary = "상담 요청한 전문가의 상세 정보를 조회합니다.")
+    @GetMapping("/experts/{expertId}")
+    public ApiResponseDto<UserConsultationDto.ExpertRequestedDto> getExpertDetail(
+            @PathVariable Long expertId
+    ) {
+        ConsultationRequest request = consultationRequestQueryService.getRequestedExpertDetail(expertId);
+        UserConsultationDto.ExpertRequestedDto detailDto = UserConsultationConvert.toDetailDto(request);
+        return ApiResponseDto.onSuccess(detailDto);
     }
 
 }

--- a/src/main/java/com/my_medi/api/consultation/dto/UserConsultationDto.java
+++ b/src/main/java/com/my_medi/api/consultation/dto/UserConsultationDto.java
@@ -27,17 +27,17 @@ public class UserConsultationDto {
 
     @Data
     @Builder
-    public static class UserConsultationDetailDto {
+    public static class ExpertRequestedDto {
         private Long expertId;
         private String name;
         private String nickname;
         private String phoneNumber;
         private String introSentence;
         private String profileImageUrl;
-        private LocalDate startedAt;
+        private LocalDate matchedAt;
         private String introduction;
         private String organization;
-        private String specialty;
+        private Specialty specialty;
         private List<String> career;
     }
 }

--- a/src/main/java/com/my_medi/api/consultation/dto/UserConsultationDto.java
+++ b/src/main/java/com/my_medi/api/consultation/dto/UserConsultationDto.java
@@ -6,18 +6,38 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDate;
+import java.util.List;
 
-@Data
-@Builder
 public class UserConsultationDto {
-    private Long consultationId;
-    private Long expertId;
-    private RequestStatus status;
-    private Specialty specialty;
-    private String name;
-    private String nickname;
-    private String profileImgUrl;
-    private String phoneNumber;
-    private String introSentence;
-    private LocalDate requestDate;
+
+    @Data
+    @Builder
+    public static class UserConsultationStatusDto {
+        private Long consultationId;
+        private Long expertId;
+        private RequestStatus status;
+        private Specialty specialty;
+        private String name;
+        private String nickname;
+        private String profileImgUrl;
+        private String phoneNumber;
+        private String introSentence;
+        private LocalDate requestDate;
+    }
+
+    @Data
+    @Builder
+    public static class UserConsultationDetailDto {
+        private Long expertId;
+        private String name;
+        private String nickname;
+        private String phoneNumber;
+        private String introSentence;
+        private String profileImageUrl;
+        private LocalDate startedAt;
+        private String introduction;
+        private String organization;
+        private String specialty;
+        private List<String> career;
+    }
 }

--- a/src/main/java/com/my_medi/api/consultation/dto/UserConsultationDto.java
+++ b/src/main/java/com/my_medi/api/consultation/dto/UserConsultationDto.java
@@ -27,11 +27,26 @@ public class UserConsultationDto {
 
     @Data
     @Builder
-    public static class ExpertRequestedDto {
+    public static class ExpertAcceptedDto {
         private Long expertId;
         private String name;
         private String nickname;
         private String phoneNumber;
+        private String introSentence;
+        private String profileImageUrl;
+        private LocalDate matchedAt;
+        private String introduction;
+        private String organization;
+        private Specialty specialty;
+        private List<String> career;
+    }
+
+    @Data
+    @Builder
+    public static class ExpertRequestedDto {
+        private Long expertId;
+        private String name;
+        private String nickname;
         private String introSentence;
         private String profileImageUrl;
         private LocalDate requestedAt;
@@ -39,5 +54,6 @@ public class UserConsultationDto {
         private String organization;
         private Specialty specialty;
         private List<String> career;
+        private int requestCount;
     }
 }

--- a/src/main/java/com/my_medi/api/consultation/dto/UserConsultationDto.java
+++ b/src/main/java/com/my_medi/api/consultation/dto/UserConsultationDto.java
@@ -34,7 +34,7 @@ public class UserConsultationDto {
         private String phoneNumber;
         private String introSentence;
         private String profileImageUrl;
-        private LocalDate matchedAt;
+        private LocalDate requestedAt;
         private String introduction;
         private String organization;
         private Specialty specialty;

--- a/src/main/java/com/my_medi/api/consultation/mapper/ExpertConsultationConverter.java
+++ b/src/main/java/com/my_medi/api/consultation/mapper/ExpertConsultationConverter.java
@@ -2,6 +2,7 @@ package com.my_medi.api.consultation.mapper;
 
 import com.my_medi.api.consultation.dto.ExpertConsultationDto;
 import com.my_medi.common.util.BirthDateUtil;
+import com.my_medi.common.util.FormUtil;
 import com.my_medi.domain.consultationRequest.entity.ConsultationRequest;
 import com.my_medi.domain.user.entity.User;
 
@@ -19,9 +20,7 @@ public class ExpertConsultationConverter {
                 .gender(user.getGender())
                 .weight(user.getWeight())
                 .height(user.getHeight())
-                .age(user.getBirthDate() != null
-                        ? "만 " + BirthDateUtil.getAge(user.getBirthDate()) + "세"
-                        : "정보 없음")
+                .age(FormUtil.formatAge(user.getBirthDate()))
                 .build();
     }
 
@@ -36,7 +35,7 @@ public class ExpertConsultationConverter {
                 .height(user.getHeight())
                 .weight(user.getWeight())
                 .profileImage(user.getProfileImgUrl())
-                .age(String.valueOf("만 "+BirthDateUtil.getAge(user.getBirthDate())) + "세")
+                .age(FormUtil.formatAge(user.getBirthDate()))
                 //TODO: 최근 건강검진일, 건강관심분야 추가
                 .build();
     }

--- a/src/main/java/com/my_medi/api/consultation/mapper/ExpertConsultationConverter.java
+++ b/src/main/java/com/my_medi/api/consultation/mapper/ExpertConsultationConverter.java
@@ -19,7 +19,9 @@ public class ExpertConsultationConverter {
                 .gender(user.getGender())
                 .weight(user.getWeight())
                 .height(user.getHeight())
-                .age(String.valueOf("만 "+BirthDateUtil.getAge(user.getBirthDate())) + "세")
+                .age(user.getBirthDate() != null
+                        ? "만 " + BirthDateUtil.getAge(user.getBirthDate()) + "세"
+                        : "정보 없음")
                 .build();
     }
 

--- a/src/main/java/com/my_medi/api/consultation/mapper/UserConsultationConvert.java
+++ b/src/main/java/com/my_medi/api/consultation/mapper/UserConsultationConvert.java
@@ -3,6 +3,9 @@ package com.my_medi.api.consultation.mapper;
 import com.my_medi.api.consultation.dto.UserConsultationDto;
 import com.my_medi.domain.consultationRequest.entity.ConsultationRequest;
 import com.my_medi.domain.expert.entity.Expert;
+
+import java.time.LocalDate;
+
 import static com.my_medi.common.util.PeriodUtil.calculateMonthsBetween;
 
 
@@ -52,17 +55,17 @@ public class UserConsultationConvert {
     }
 
     public static UserConsultationDto.ExpertRequestedDto toRequestedDetailDto(
-            ConsultationRequest request, int requestCount
+            Expert expert,
+            int requestCount,
+            LocalDate requestedAt
     ) {
-        Expert expert = request.getExpert();
-
         return UserConsultationDto.ExpertRequestedDto.builder()
                 .expertId(expert.getId())
                 .name(expert.getName())
                 .nickname(expert.getNickname())
                 .introSentence(expert.getIntroSentence())
                 .profileImageUrl(expert.getProfileImgUrl())
-                .requestedAt(request.getCreatedDate().toLocalDate())
+                .requestedAt(requestedAt)
                 .introduction(expert.getIntroduction())
                 .organization(expert.getOrganizationName())
                 .specialty(expert.getSpecialty())

--- a/src/main/java/com/my_medi/api/consultation/mapper/UserConsultationConvert.java
+++ b/src/main/java/com/my_medi/api/consultation/mapper/UserConsultationConvert.java
@@ -35,7 +35,7 @@ public class UserConsultationConvert {
                 .phoneNumber(expert.getPhoneNumber())
                 .introSentence(expert.getIntroSentence())
                 .profileImageUrl(expert.getProfileImgUrl())
-                .matchedAt(request.getCreatedDate().toLocalDate())
+                .requestedAt(request.getCreatedDate().toLocalDate())
                 .introduction(expert.getIntroduction())
                 .organization(expert.getOrganizationName())
                 .specialty(expert.getSpecialty())

--- a/src/main/java/com/my_medi/api/consultation/mapper/UserConsultationConvert.java
+++ b/src/main/java/com/my_medi/api/consultation/mapper/UserConsultationConvert.java
@@ -1,6 +1,7 @@
 package com.my_medi.api.consultation.mapper;
 
 import com.my_medi.api.consultation.dto.UserConsultationDto;
+import com.my_medi.common.util.FormUtil;
 import com.my_medi.domain.consultationRequest.entity.ConsultationRequest;
 import com.my_medi.domain.expert.entity.Expert;
 
@@ -44,13 +45,14 @@ public class UserConsultationConvert {
                 .specialty(expert.getSpecialty())
                 .career(
                         expert.getCareers().stream()
-                                .map(career -> String.format(
-                                        "%s %d개월",
+                                .map(career -> FormUtil.formatCareerPeriod(
                                         career.getJobTitle(),
-                                        calculateMonthsBetween(career.getStartDate(), career.getEndDate())
+                                        career.getStartDate(),
+                                        career.getEndDate()
                                 ))
                                 .toList()
                 )
+
                 .build();
     }
 
@@ -71,13 +73,14 @@ public class UserConsultationConvert {
                 .specialty(expert.getSpecialty())
                 .career(
                         expert.getCareers().stream()
-                                .map(career -> String.format(
-                                        "%s %d개월",
+                                .map(career -> FormUtil.formatCareerPeriod(
                                         career.getJobTitle(),
-                                        calculateMonthsBetween(career.getStartDate(), career.getEndDate())
+                                        career.getStartDate(),
+                                        career.getEndDate()
                                 ))
                                 .toList()
                 )
+
                 .requestCount(requestCount)
                 .build();
     }

--- a/src/main/java/com/my_medi/api/consultation/mapper/UserConsultationConvert.java
+++ b/src/main/java/com/my_medi/api/consultation/mapper/UserConsultationConvert.java
@@ -25,14 +25,41 @@ public class UserConsultationConvert {
                 .build();
     }
 
-    public static UserConsultationDto.ExpertRequestedDto toDetailDto(ConsultationRequest request) {
+    public static UserConsultationDto.ExpertAcceptedDto toDetailDto(ConsultationRequest request) {
+        Expert expert = request.getExpert();
+
+        return UserConsultationDto.ExpertAcceptedDto.builder()
+                .expertId(expert.getId())
+                .name(expert.getName())
+                .nickname(expert.getNickname())
+                .phoneNumber(expert.getPhoneNumber())
+                .introSentence(expert.getIntroSentence())
+                .profileImageUrl(expert.getProfileImgUrl())
+                .matchedAt(request.getCreatedDate().toLocalDate())
+                .introduction(expert.getIntroduction())
+                .organization(expert.getOrganizationName())
+                .specialty(expert.getSpecialty())
+                .career(
+                        expert.getCareers().stream()
+                                .map(career -> String.format(
+                                        "%s %d개월",
+                                        career.getJobTitle(),
+                                        calculateMonthsBetween(career.getStartDate(), career.getEndDate())
+                                ))
+                                .toList()
+                )
+                .build();
+    }
+
+    public static UserConsultationDto.ExpertRequestedDto toRequestedDetailDto(
+            ConsultationRequest request, int requestCount
+    ) {
         Expert expert = request.getExpert();
 
         return UserConsultationDto.ExpertRequestedDto.builder()
                 .expertId(expert.getId())
                 .name(expert.getName())
                 .nickname(expert.getNickname())
-                .phoneNumber(expert.getPhoneNumber())
                 .introSentence(expert.getIntroSentence())
                 .profileImageUrl(expert.getProfileImgUrl())
                 .requestedAt(request.getCreatedDate().toLocalDate())
@@ -48,6 +75,10 @@ public class UserConsultationConvert {
                                 ))
                                 .toList()
                 )
+                .requestCount(requestCount)
                 .build();
     }
+
+
+
 }

--- a/src/main/java/com/my_medi/api/consultation/mapper/UserConsultationConvert.java
+++ b/src/main/java/com/my_medi/api/consultation/mapper/UserConsultationConvert.java
@@ -3,6 +3,9 @@ package com.my_medi.api.consultation.mapper;
 import com.my_medi.api.consultation.dto.UserConsultationDto;
 import com.my_medi.domain.consultationRequest.entity.ConsultationRequest;
 import com.my_medi.domain.expert.entity.Expert;
+import static com.my_medi.common.util.PeriodUtil.calculateMonthsBetween;
+
+
 
 public class UserConsultationConvert {
 
@@ -19,6 +22,32 @@ public class UserConsultationConvert {
                 .phoneNumber(expert.getPhoneNumber())
                 .introSentence(expert.getIntroSentence())
                 .requestDate(request.getCreatedDate().toLocalDate())
+                .build();
+    }
+
+    public static UserConsultationDto.ExpertRequestedDto toDetailDto(ConsultationRequest request) {
+        Expert expert = request.getExpert();
+
+        return UserConsultationDto.ExpertRequestedDto.builder()
+                .expertId(expert.getId())
+                .name(expert.getName())
+                .nickname(expert.getNickname())
+                .phoneNumber(expert.getPhoneNumber())
+                .introSentence(expert.getIntroSentence())
+                .profileImageUrl(expert.getProfileImgUrl())
+                .matchedAt(request.getCreatedDate().toLocalDate())
+                .introduction(expert.getIntroduction())
+                .organization(expert.getOrganizationName())
+                .specialty(expert.getSpecialty())
+                .career(
+                        expert.getCareers().stream()
+                                .map(career -> String.format(
+                                        "%s %d개월",
+                                        career.getJobTitle(),
+                                        calculateMonthsBetween(career.getStartDate(), career.getEndDate())
+                                ))
+                                .toList()
+                )
                 .build();
     }
 }

--- a/src/main/java/com/my_medi/api/consultation/mapper/UserConsultationConvert.java
+++ b/src/main/java/com/my_medi/api/consultation/mapper/UserConsultationConvert.java
@@ -4,11 +4,11 @@ import com.my_medi.api.consultation.dto.UserConsultationDto;
 import com.my_medi.domain.consultationRequest.entity.ConsultationRequest;
 import com.my_medi.domain.expert.entity.Expert;
 
-
 public class UserConsultationConvert {
-    public static UserConsultationDto toDto(ConsultationRequest request) {
+
+    public static UserConsultationDto.UserConsultationStatusDto toDto(ConsultationRequest request) {
         Expert expert = request.getExpert();
-        return UserConsultationDto.builder()
+        return UserConsultationDto.UserConsultationStatusDto.builder()
                 .consultationId(request.getId())
                 .expertId(expert.getId())
                 .status(request.getRequestStatus())

--- a/src/main/java/com/my_medi/common/util/FormUtil.java
+++ b/src/main/java/com/my_medi/common/util/FormUtil.java
@@ -1,0 +1,18 @@
+package com.my_medi.common.util;
+
+import static com.my_medi.common.util.PeriodUtil.calculateMonthsBetween;
+
+import java.time.LocalDate;
+
+public class FormUtil {
+
+    public static String formatAge(String birthDate) {
+        if (birthDate == null) return "정보 없음";
+        return "만 " + BirthDateUtil.getAge(birthDate) + "세";
+    }
+
+    public static String formatCareerPeriod(String jobTitle, LocalDate start, LocalDate end) {
+        int months = (int) calculateMonthsBetween(start, end);
+        return String.format("%s %d개월", jobTitle, months);
+    }
+}

--- a/src/main/java/com/my_medi/common/util/PeriodUtil.java
+++ b/src/main/java/com/my_medi/common/util/PeriodUtil.java
@@ -1,0 +1,11 @@
+package com.my_medi.common.util;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+public class PeriodUtil {
+    public static long calculateMonthsBetween(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null) return 0L;
+        return ChronoUnit.MONTHS.between(startDate.withDayOfMonth(1), endDate.withDayOfMonth(1));
+    }
+}

--- a/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
@@ -43,5 +43,12 @@ public interface ConsultationRequestRepository extends JpaRepository<Consultatio
     List<ConsultationRequest> findLatestRequestedByExpert(@Param("expertId") Long expertId,
                                                           @Param("status") RequestStatus status);
 
+    @Query("SELECT r FROM ConsultationRequest r " +
+            "WHERE r.user.id = :userId AND r.expert.id = :expertId AND r.requestStatus = :status")
+    Optional<ConsultationRequest> findMatchedRequest(@Param("userId") Long userId,
+                                                     @Param("expertId") Long expertId,
+                                                     @Param("status") RequestStatus status);
+
+
 
 }

--- a/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
@@ -38,10 +38,12 @@ public interface ConsultationRequestRepository extends JpaRepository<Consultatio
     List<ConsultationRequest> findByUserIdAndExpertIdAndRequestStatus(Long userId, Long expertId, RequestStatus requestStatus);
 
     @Query("SELECT r FROM ConsultationRequest r " +
-            "WHERE r.expert.id = :expertId AND r.requestStatus = :status " +
+            "WHERE r.expert.id = :expertId AND r.user.id = :userId AND r.requestStatus = :status " +
             "ORDER BY r.createdDate DESC")
-    List<ConsultationRequest> findLatestRequestedByExpert(@Param("expertId") Long expertId,
+    List<ConsultationRequest> findLatestRequestedByExpert(@Param("userId") Long userId,
+                                                          @Param("expertId") Long expertId,
                                                           @Param("status") RequestStatus status);
+
 
     @Query("SELECT r FROM ConsultationRequest r " +
             "WHERE r.user.id = :userId AND r.expert.id = :expertId AND r.requestStatus = :status")

--- a/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -55,5 +56,14 @@ public interface ConsultationRequestRepository extends JpaRepository<Consultatio
                                                      @Param("status") RequestStatus status);
 
 
+    @Query("SELECT r.createdDate FROM ConsultationRequest r " +
+            "WHERE r.user.id = :userId AND r.expert.id = :expertId AND r.requestStatus = :status " +
+            "ORDER BY r.createdDate DESC")
+    List<LocalDateTime> findLatestRequestedDates(
+            @Param("userId") Long userId,
+            @Param("expertId") Long expertId,
+            @Param("status") RequestStatus status,
+            Pageable pageable
+    );
 
 }

--- a/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
@@ -5,8 +5,11 @@ import com.my_medi.domain.consultationRequest.entity.RequestStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ConsultationRequestRepository extends JpaRepository<ConsultationRequest, Long> {
 
@@ -33,6 +36,12 @@ public interface ConsultationRequestRepository extends JpaRepository<Consultatio
     boolean existsByExpertIdAndUserIdAndRequestStatus(Long expertId, Long userId, RequestStatus requestStatus);
 
     List<ConsultationRequest> findByUserIdAndExpertIdAndRequestStatus(Long userId, Long expertId, RequestStatus requestStatus);
+
+    @Query("SELECT r FROM ConsultationRequest r " +
+            "WHERE r.expert.id = :expertId AND r.requestStatus = :status " +
+            "ORDER BY r.createdDate DESC")
+    List<ConsultationRequest> findLatestRequestedByExpert(@Param("expertId") Long expertId,
+                                                          @Param("status") RequestStatus status);
 
 
 }

--- a/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
@@ -44,6 +44,9 @@ public interface ConsultationRequestRepository extends JpaRepository<Consultatio
                                                           @Param("expertId") Long expertId,
                                                           @Param("status") RequestStatus status);
 
+    int countByUserIdAndExpertIdAndRequestStatus(Long userId, Long expertId, RequestStatus status);
+
+
 
     @Query("SELECT r FROM ConsultationRequest r " +
             "WHERE r.user.id = :userId AND r.expert.id = :expertId AND r.requestStatus = :status")

--- a/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestQueryService.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestQueryService.java
@@ -18,4 +18,7 @@ public interface ConsultationRequestQueryService {
     Page<ConsultationRequest> getRequestByExpert(Long expertId, RequestStatus status, Pageable pageable);
 
     Page<ConsultationRequest> getAllRequestByExpert(Long expertId, Pageable pageable);
+
+    ConsultationRequest getRequestedExpertDetail(Long expertId);
+
 }

--- a/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestQueryService.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestQueryService.java
@@ -21,4 +21,7 @@ public interface ConsultationRequestQueryService {
 
     ConsultationRequest getRequestedExpertDetail(Long expertId);
 
+    ConsultationRequest getMatchedExpertDetail(Long userId, Long expertId);
+
+
 }

--- a/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestQueryService.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestQueryService.java
@@ -19,7 +19,7 @@ public interface ConsultationRequestQueryService {
 
     Page<ConsultationRequest> getAllRequestByExpert(Long expertId, Pageable pageable);
 
-    ConsultationRequest getRequestedExpertDetail(Long expertId);
+    ConsultationRequest getRequestedExpertDetail(Long userId, Long expertId);
 
     ConsultationRequest getMatchedExpertDetail(Long userId, Long expertId);
 

--- a/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestQueryServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestQueryServiceImpl.java
@@ -47,9 +47,9 @@ public class ConsultationRequestQueryServiceImpl implements ConsultationRequestQ
     }
 
     @Override
-    public ConsultationRequest getRequestedExpertDetail(Long expertId) {
+    public ConsultationRequest getRequestedExpertDetail(Long userId, Long expertId) {
         List<ConsultationRequest> results =
-                consultationRequestRepository.findLatestRequestedByExpert(expertId, RequestStatus.REQUESTED);
+                consultationRequestRepository.findLatestRequestedByExpert(userId, expertId, RequestStatus.REQUESTED);
 
         return results.stream()
                 .findFirst()

--- a/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestQueryServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestQueryServiceImpl.java
@@ -56,5 +56,11 @@ public class ConsultationRequestQueryServiceImpl implements ConsultationRequestQ
                 .orElseThrow(() -> ConsultationRequestHandler.NOT_FOUND);
     }
 
+    @Override
+    public ConsultationRequest getMatchedExpertDetail(Long userId, Long expertId) {
+        return consultationRequestRepository
+                .findMatchedRequest(userId, expertId, RequestStatus.ACCEPTED)
+                .orElseThrow(() -> ConsultationRequestHandler.NOT_FOUND);
+    }
 }
 

--- a/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestQueryServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestQueryServiceImpl.java
@@ -45,5 +45,16 @@ public class ConsultationRequestQueryServiceImpl implements ConsultationRequestQ
     public List<ConsultationRequest> getRequestByUser(Long userId, RequestStatus requestStatus) {
         return consultationRequestRepository.findByUserIdAndRequestStatus(userId, requestStatus);
     }
+
+    @Override
+    public ConsultationRequest getRequestedExpertDetail(Long expertId) {
+        List<ConsultationRequest> results =
+                consultationRequestRepository.findLatestRequestedByExpert(expertId, RequestStatus.REQUESTED);
+
+        return results.stream()
+                .findFirst()
+                .orElseThrow(() -> ConsultationRequestHandler.NOT_FOUND);
+    }
+
 }
 


### PR DESCRIPTION
## #️⃣ 요약 설명
유저 상담 요청 상태별 전문가 조회 API 구현

## 📝 작업 내용

> 상태가 Requested 일때  전문가 조회 API 구현
상태가 Approved 일때 전문가 조회 API 구현


## 동작 확인
<img width="1470" height="956" alt="스크린샷 2025-08-06 오후 2 04 25" src="https://github.com/user-attachments/assets/63172343-c597-4d8c-822b-eef971f4c717" />
<img width="1443" height="833" alt="스크린샷 2025-08-06 오후 7 43 54" src="https://github.com/user-attachments/assets/16153c01-0846-448c-9687-8d19116b11f1" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 요청한 전문가의 상세 정보를 조회할 수 있는 두 개의 새로운 조회 엔드포인트가 추가되었습니다.
  * 매칭된 전문가의 상세 정보를 확인할 수 있는 기능이 추가되었습니다.

* **개선 및 리팩터링**
  * 상담 요청 및 전문가 관련 DTO 구조가 세분화되어, 상황별로 더 풍부하고 명확한 정보를 제공합니다.
  * 경력 기간이 월 단위로 계산되어 경력 정보가 더욱 상세하게 표시됩니다.
  * 나이 정보 포맷이 통일되어 보다 일관된 사용자 경험을 제공합니다.

* **기타**
  * 일부 API 반환 타입이 변경되어 더 구체적인 상태 정보를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->