### PR TITLE
[MEDI-89] dummy data schedule

### DIFF
--- a/src/main/java/com/my_medi/api/common/controller/DummyApiController.java
+++ b/src/main/java/com/my_medi/api/common/controller/DummyApiController.java
@@ -4,6 +4,7 @@ import com.my_medi.api.common.dto.ApiResponseDto;
 import com.my_medi.domain.expert.service.ExpertCommandService;
 import com.my_medi.domain.notification.service.ExpertNotificationCommandService;
 import com.my_medi.domain.notification.service.UserNotificationCommandService;
+import com.my_medi.domain.schedule.service.ScheduleCommandService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ public class DummyApiController {
     private final ExpertCommandService expertCommandService;
     private final ExpertNotificationCommandService expertNotificationCommandService;
     private final UserNotificationCommandService userNotificationCommandService;
+    private final ScheduleCommandService scheduleCommandService;
 
     @Operation(summary = "전문가 더미 생성 API")
     @PostMapping("/experts")
@@ -39,6 +41,17 @@ public class DummyApiController {
     public ApiResponseDto<String> createNotificationToExpertDummy(@PathVariable Long expertId,
                                                                   @RequestParam int count) {
         expertNotificationCommandService.sendDummyNotificationToExpert(expertId, count);
+        return ApiResponseDto.onSuccess("success");
+    }
+
+    @Operation(summary = "스케줄 더미 생성 API")
+    @PostMapping("/schedules/experts/{expertId}/users/{userId}")
+    public ApiResponseDto<String> createScheduleDummy(@PathVariable Long expertId,
+                                                      @PathVariable Long userId,
+                                                      @RequestParam int year,
+                                                      @RequestParam int month,
+                                                      @RequestParam int count) {
+        scheduleCommandService.createScheduleDummy(expertId, userId, year, month, count);
         return ApiResponseDto.onSuccess("success");
     }
 }

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleCommandService.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleCommandService.java
@@ -11,4 +11,6 @@ public interface ScheduleCommandService {
     Long editSchedule(Long expertId, Long scheduleId , EditScheduleDto editScheduleDto);
 
     Long removeSchedule(Long expertId, Long scheduleId);
+
+    void createScheduleDummy(Long expertId, Long userId, int year, int month, int count);
 }

--- a/src/main/java/com/my_medi/domain/schedule/service/ScheduleCommandServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/schedule/service/ScheduleCommandServiceImpl.java
@@ -6,6 +6,7 @@ import com.my_medi.api.schedule.dto.RegisterScheduleDto;
 import com.my_medi.domain.consultationRequest.entity.RequestStatus;
 import com.my_medi.domain.consultationRequest.repository.ConsultationRequestRepository;
 import com.my_medi.domain.expert.entity.Expert;
+import com.my_medi.domain.expert.exception.ExpertHandler;
 import com.my_medi.domain.expert.repository.ExpertRepository;
 import com.my_medi.domain.schedule.entity.Schedule;
 import com.my_medi.domain.schedule.exception.ScheduleErrorStatus;
@@ -15,8 +16,14 @@ import com.my_medi.domain.user.entity.User;
 import com.my_medi.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.units.qual.A;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -33,11 +40,12 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
     @Override
     public Long registerScheduleToUser(Expert expert, Long userId, RegisterScheduleDto registerScheduleDto) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ScheduleHandler(ScheduleErrorStatus.USER_NOT_FOUND));
+                .orElseThrow(() -> ScheduleHandler.NOT_FOUND);
 
         boolean isMatched = consultationRequestRepository
                 .existsByExpertIdAndUserIdAndRequestStatus(expert.getId(), user.getId(), RequestStatus.ACCEPTED);
 
+        //TODO exception form
         if (!isMatched) {
             throw new ScheduleHandler(ScheduleErrorStatus.NOT_MATCHED_CONSULTATION);
         }
@@ -78,6 +86,39 @@ public class ScheduleCommandServiceImpl implements ScheduleCommandService {
 //        validateExpert(schedule, expertId);
         scheduleRepository.delete(schedule);
         return scheduleId;
+    }
+
+    @Override
+    public void createScheduleDummy(Long expertId, Long userId, int year, int month, int count) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> ScheduleHandler.NOT_FOUND);
+        Expert expert = expertRepository.findById(expertId)
+                .orElseThrow(() -> ExpertHandler.NOT_FOUND);
+
+        boolean isMatched = consultationRequestRepository
+                .existsByExpertIdAndUserIdAndRequestStatus(expertId, userId, RequestStatus.ACCEPTED);
+
+        if (!isMatched) {
+            throw new ScheduleHandler(ScheduleErrorStatus.NOT_MATCHED_CONSULTATION);
+        }
+
+        List<Schedule> scheduleList = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            scheduleList.add(
+                    Schedule.builder()
+                            .expert(expert)
+                            .user(user)
+                            .title("dummy title")
+                            .location("kwang-woon univ")
+                            .meetingDate(LocalDate.of(year, month, new Random().nextInt(30) + 1))
+                            .hour(1)
+                            .minute(0)
+                            .isAm(false)
+                            .memo("dummy memo" + i)
+                            .build()
+            );
+        }
+        scheduleRepository.saveAll(scheduleList);
     }
 
 //    private void validateExpert(Schedule schedule, Long expertId) {


### PR DESCRIPTION
## #️⃣ 요약 설명
>유저와 전문가 사이의 스케줄 더미데이터 생성 API 
## 📝 작업 내용


```java
 @Operation(summary = "스케줄 더미 생성 API")
    @PostMapping("/schedules/experts/{expertId}/users/{userId}")
    public ApiResponseDto<String> createScheduleDummy(@PathVariable Long expertId,
                                                      @PathVariable Long userId,
                                                      @RequestParam int year,
                                                      @RequestParam int month,
                                                      @RequestParam int count) {
        scheduleCommandService.createScheduleDummy(expertId, userId, year, month, count);
        return ApiResponseDto.onSuccess("success");
    }
```

## 동작 확인

<img width="970" height="675" alt="스크린샷 2025-08-07 오후 5 45 40" src="https://github.com/user-attachments/assets/d8e30ba3-b71a-428d-a816-f26668fd9adb" />

<img width="573" height="439" alt="스크린샷 2025-08-07 오후 5 45 57" src="https://github.com/user-attachments/assets/c83d73b3-eb81-4194-a9eb-5cd790d946b3" />

## 💬 리뷰 요구사항(선택)

x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 전문가와 사용자의 "마이홈" 프로필 요약 조회 API가 추가되었습니다.
  * 사용자가 특정 날짜의 스케줄 목록을 조회할 수 있는 기능이 추가되었습니다.
  * 전문가 상세 정보 및 요청/매칭 상태별 상세 조회 API가 추가되었습니다.
  * 더 세분화된 상담 요청/매칭 DTO 및 커리어, 경력 기간 포맷 유틸이 도입되었습니다.
  * 더미 스케줄 생성 API가 추가되었습니다.

* **기능 개선**
  * 전문가, 사용자, 상담 관련 DTO 구조가 세분화되어 정보 제공이 향상되었습니다.
  * 전문가 프로필 및 상담 요청 관련 엔드포인트가 명확하게 분리 및 개선되었습니다.
  * 일부 API의 설명 및 반환 데이터가 실제 사용 목적에 맞게 조정되었습니다.

* **버그 수정**
  * 사용자 회원가입 시 닉네임이 정상적으로 저장되도록 개선되었습니다.

* **기타**
  * 기존 사용하지 않는 API 및 메서드가 비활성화(주석처리)되었습니다.
  * 일부 필드명 및 반환 타입이 일관성 있게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->