### PR TITLE
[MEDI-86] reissue error resolve

### DIFF
--- a/src/main/java/com/my_medi/common/consts/StaticVariable.java
+++ b/src/main/java/com/my_medi/common/consts/StaticVariable.java
@@ -10,7 +10,7 @@ public class StaticVariable {
     public static final String GRANT_TYPE = "authorization_code";
 
     //JWT
-    public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // 30분
+    public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 1; // 30분
     public static final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 7; // 7일
 
     //HealthReportData JSON 필드 키

--- a/src/main/java/com/my_medi/common/consts/StaticVariable.java
+++ b/src/main/java/com/my_medi/common/consts/StaticVariable.java
@@ -8,9 +8,11 @@ public class StaticVariable {
     public static final String BEARER = "Bearer ";
     public static final String AUTHORIZATION = "Authorization";
     public static final String GRANT_TYPE = "authorization_code";
+    public static final String REISSUE_ENDPOINT = "/api/v1/tokens/reissue";
+    public static final String HEALTH_CHECK_ENDPOINT = "/api/v1/test/health-check";
 
     //JWT
-    public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 1; // 30분
+    public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // 30분
     public static final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 7; // 7일
 
     //HealthReportData JSON 필드 키

--- a/src/main/java/com/my_medi/security/config/SecurityConfig.java
+++ b/src/main/java/com/my_medi/security/config/SecurityConfig.java
@@ -94,8 +94,7 @@ public class SecurityConfig {
     //[POST] 인증 없이 접근 허용할 경로 목록
     private String[] permitAllPostPaths() {
         return new String[]{
-                "/api/v1/tokens/login",
-                "/api/v1/tokens/reissue",
+                "/api/v1/tokens/**",
                 "/api/v1/users",
                 "/api/v1/experts",
                 "/api/v1/images",

--- a/src/main/java/com/my_medi/security/exception/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/my_medi/security/exception/JwtAuthenticationEntryPoint.java
@@ -17,6 +17,6 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
         SecurityErrorStatus errorStatus = SecurityErrorStatus.AUTH_MUST_AUTHORIZED_URI;
-        CustomErrorSend.handleException(response, errorStatus, authException.getMessage());
+        CustomErrorSend.handleException(response, errorStatus, errorStatus.getMessage());
     }
 }

--- a/src/main/java/com/my_medi/security/exception/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/my_medi/security/exception/JwtAuthenticationEntryPoint.java
@@ -17,6 +17,6 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
         SecurityErrorStatus errorStatus = SecurityErrorStatus.AUTH_MUST_AUTHORIZED_URI;
-        CustomErrorSend.handleException(response, errorStatus, errorStatus.getMessage());
+        CustomErrorSend.handleException(response, errorStatus, authException.getMessage());
     }
 }

--- a/src/main/java/com/my_medi/security/exception/JwtAuthenticationException.java
+++ b/src/main/java/com/my_medi/security/exception/JwtAuthenticationException.java
@@ -4,6 +4,8 @@ import com.my_medi.common.exception.ErrorStatus;
 import com.my_medi.common.exception.GeneralException;
 import org.springframework.security.core.AuthenticationException;
 
+import java.io.IOException;
+
 public class JwtAuthenticationException extends AuthenticationException {
     public static final AuthenticationException UNAUTHORIZED_LOGIN_DATA
             = new JwtAuthenticationException(SecurityErrorStatus.AUTH_UNAUTHORIZED_LOGIN_DATA_RETRIEVAL_ERROR);
@@ -20,6 +22,8 @@ public class JwtAuthenticationException extends AuthenticationException {
 
     public static final AuthenticationException AUTH_NULL
             = new JwtAuthenticationException(SecurityErrorStatus.AUTH_IS_NULL);
+    public static final AuthenticationException TOKEN_IS_EXPIRED
+            = new JwtAuthenticationException(SecurityErrorStatus.AUTH_TOKEN_HAS_EXPIRED);
 
     public JwtAuthenticationException(SecurityErrorStatus errorStatus) {
         super(errorStatus.name());

--- a/src/main/java/com/my_medi/security/exception/JwtAuthenticationException.java
+++ b/src/main/java/com/my_medi/security/exception/JwtAuthenticationException.java
@@ -12,7 +12,17 @@ public class JwtAuthenticationException extends AuthenticationException {
 
     public static final AuthenticationException WRONG_PASSWORD
             = new JwtAuthenticationException(SecurityErrorStatus.AUTH_WRONG_PASSWORD);
+    public static final AuthenticationException INVALID_TOKEN
+            = new JwtAuthenticationException(SecurityErrorStatus.AUTH_INVALID_TOKEN);
+
+    public static final AuthenticationException TOKEN_IS_UNSUPPORTED
+            = new JwtAuthenticationException(SecurityErrorStatus.AUTH_TOKEN_IS_UNSUPPORTED);
+
+    public static final AuthenticationException AUTH_NULL
+            = new JwtAuthenticationException(SecurityErrorStatus.AUTH_IS_NULL);
+
     public JwtAuthenticationException(SecurityErrorStatus errorStatus) {
         super(errorStatus.name());
     }
+
 }

--- a/src/main/java/com/my_medi/security/exception/JwtAuthenticationExpiredException.java
+++ b/src/main/java/com/my_medi/security/exception/JwtAuthenticationExpiredException.java
@@ -2,12 +2,12 @@ package com.my_medi.security.exception;
 
 import org.springframework.security.core.AuthenticationException;
 
-public class JwtAuthenticationExpiredException extends JwtAuthenticationException{
+public class JwtAuthenticationExpiredException extends AuthenticationException{
 
     public static final AuthenticationException EXPIRED =
-            new JwtAuthenticationException(SecurityErrorStatus.AUTH_TOKEN_HAS_EXPIRED);
+            new JwtAuthenticationExpiredException(SecurityErrorStatus.AUTH_TOKEN_HAS_EXPIRED);
 
     public JwtAuthenticationExpiredException(SecurityErrorStatus errorStatus) {
-        super(errorStatus);
+        super(errorStatus.name());
     }
 }

--- a/src/main/java/com/my_medi/security/exception/JwtAuthenticationExpiredException.java
+++ b/src/main/java/com/my_medi/security/exception/JwtAuthenticationExpiredException.java
@@ -1,0 +1,13 @@
+package com.my_medi.security.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class JwtAuthenticationExpiredException extends JwtAuthenticationException{
+
+    public static final AuthenticationException EXPIRED =
+            new JwtAuthenticationException(SecurityErrorStatus.AUTH_TOKEN_HAS_EXPIRED);
+
+    public JwtAuthenticationExpiredException(SecurityErrorStatus errorStatus) {
+        super(errorStatus);
+    }
+}

--- a/src/main/java/com/my_medi/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/my_medi/security/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.my_medi.security.filter;
 
+import com.my_medi.common.consts.StaticVariable;
 import com.my_medi.security.exception.JwtAuthenticationException;
 import com.my_medi.security.exception.JwtAuthenticationExpiredException;
 import jakarta.servlet.FilterChain;
@@ -16,6 +17,9 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+
+import static com.my_medi.common.consts.StaticVariable.HEALTH_CHECK_ENDPOINT;
+import static com.my_medi.common.consts.StaticVariable.REISSUE_ENDPOINT;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -34,6 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         token = resolveToken(request);
 
         if (token != null) {
+            // 만료 케이스만 해당 필터에서 처리. 나머지는 JwtExceptionFilter 에서 처리
             try {
                 tokenService.validateToken(token);
                 // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
@@ -43,11 +48,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 log.info("set Authentication to security context for '{}', uri: '{}', Role '{}'",
                         authentication.getName(), requestURI, authentication.getAuthorities());
             } catch (JwtAuthenticationExpiredException e) {
-                if(!requestURI.equals("/api/v1/tokens/reissue")) throw JwtAuthenticationException.TOKEN_IS_EXPIRED;
-                log.debug("토큰 만료, 재발급 시도이므로 통과합니다.");
+                if(!requestURI.equals(REISSUE_ENDPOINT)) throw JwtAuthenticationException.TOKEN_IS_EXPIRED;
+                log.debug("토큰 만료지만 재발급 시도이므로 통과합니다.");
             }
         } else {
-            if (!requestURI.equals("/api/v1/test/health-check")) {
+            if (!requestURI.equals(HEALTH_CHECK_ENDPOINT)) {
                 log.info("no valid JWT token found, uri: {}", requestURI);
             }
         }

--- a/src/main/java/com/my_medi/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/my_medi/security/filter/JwtExceptionFilter.java
@@ -25,7 +25,6 @@ public class JwtExceptionFilter  extends OncePerRequestFilter {
         } catch (JwtAuthenticationException authException) {
             String errorCodeName = authException.getMessage();
             SecurityErrorStatus errorStatus = SecurityErrorStatus.valueOf(errorCodeName);
-
             CustomErrorSend.handleException(response, errorStatus, errorCodeName);
         }
     }

--- a/src/main/java/com/my_medi/security/jwt/service/TokenService.java
+++ b/src/main/java/com/my_medi/security/jwt/service/TokenService.java
@@ -22,4 +22,5 @@ public interface TokenService {
     boolean existsRefreshToken(String refreshToken);
 
     Date parseExpiration(String token);
+
 }

--- a/src/main/java/com/my_medi/security/jwt/service/TokenServiceImpl.java
+++ b/src/main/java/com/my_medi/security/jwt/service/TokenServiceImpl.java
@@ -1,7 +1,6 @@
 package com.my_medi.security.jwt.service;
 
 import com.my_medi.common.consts.StaticVariable;
-import com.my_medi.common.exception.ErrorStatus;
 import com.my_medi.common.exception.GeneralException;
 import com.my_medi.common.service.RedisService;
 import com.my_medi.domain.member.entity.Member;
@@ -16,10 +15,8 @@ import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SecurityException;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.client.AuthenticationHandler;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;

--- a/src/main/java/com/my_medi/security/jwt/service/TokenServiceImpl.java
+++ b/src/main/java/com/my_medi/security/jwt/service/TokenServiceImpl.java
@@ -7,6 +7,7 @@ import com.my_medi.common.service.RedisService;
 import com.my_medi.domain.member.entity.Member;
 import com.my_medi.domain.member.service.MemberQueryService;
 import com.my_medi.security.exception.JwtAuthenticationException;
+import com.my_medi.security.exception.JwtAuthenticationExpiredException;
 import com.my_medi.security.exception.SecurityErrorStatus;
 import com.my_medi.security.jwt.dto.JwtToken;
 import com.my_medi.security.jwt.dto.MemberLoginRequestDto;
@@ -154,16 +155,16 @@ public class TokenServiceImpl implements TokenService{
             return true;
         } catch (SecurityException | MalformedJwtException e) {
             log.info("Invalid JWT Token", e);
-            throw new JwtAuthenticationException(SecurityErrorStatus.AUTH_INVALID_TOKEN);
+            throw JwtAuthenticationException.INVALID_TOKEN;
         } catch (ExpiredJwtException e) {
             log.info("Expired JWT Token", e);
-            throw new JwtAuthenticationException(SecurityErrorStatus.AUTH_TOKEN_HAS_EXPIRED);
+            throw JwtAuthenticationExpiredException.EXPIRED;
         } catch (UnsupportedJwtException e) {
             log.info("Unsupported JWT Token", e);
-            throw new JwtAuthenticationException(SecurityErrorStatus.AUTH_TOKEN_IS_UNSUPPORTED);
+            throw JwtAuthenticationException.TOKEN_IS_UNSUPPORTED;
         } catch (IllegalArgumentException e) {
             log.info("JWT claims string is empty.", e);
-            throw new JwtAuthenticationException(SecurityErrorStatus.AUTH_IS_NULL);
+            throw JwtAuthenticationException.AUTH_NULL;
         }
     }
 


### PR DESCRIPTION
## #️⃣ 요약 설명
> 토큰 재발급 시 만료 무시
## 📝 작업 내용

기존 시큐리티 흐름은 JwtExceptionFilter -> JwtAuthenticationFilter -> authorizationFilter-> DispatchServlet 와 같이 작동되었습니다. JwtExceptionFilter에서는 filter단에서 발생하는 예외 또한 동일한 response를 가질 수 있도록 하였는데, 이 구조를 유지하면서 다음과 같은 작업 요청이 생성되었습니다.
> 재발급 시, 액세스 토큰을 헤더에 넣어도 만료되는 예외 없이 재발급에 성공하게 해주세요
위와 같은 필터흐름이기 때문에 재발급 endpoint를 permit하여도 JwtAuthenticationFilter가 우선 작동하기 때문에 예외가 발생하고 처리가 되는 구조입니다. 

따라서 재발급에만 예외를 두고자 JwtAuthenticationFilter에 JwtAuthenticationExpiredException만을 예외 처리하는 로직을 두고, 재발급 엔드포인트와 동일하다면 통과시켜주도록 설정하였습니다.

```java
@Override
    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
        // HttpServletRequest에서 JWT 토큰 추출
        HttpServletRequest httpServletRequest = ((HttpServletRequest) request);

        String requestURI = httpServletRequest.getRequestURI();
        String token = null;
        token = resolveToken(request);

        if (token != null) {
            // 만료 케이스만 해당 필터에서 처리. 나머지는 JwtExceptionFilter 에서 처리
            try {
                tokenService.validateToken(token);
                // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
                Authentication authentication = tokenService.getAuthentication(token);
                SecurityContextHolder.getContext().setAuthentication(authentication);
                request.setAttribute("username", authentication.getName());
                log.info("set Authentication to security context for '{}', uri: '{}', Role '{}'",
                        authentication.getName(), requestURI, authentication.getAuthorities());
            } catch (JwtAuthenticationExpiredException e) {
                if(!requestURI.equals(REISSUE_ENDPOINT)) throw JwtAuthenticationException.TOKEN_IS_EXPIRED;
                log.debug("토큰 만료지만 재발급 시도이므로 통과합니다.");
            }
        } else {
            if (!requestURI.equals(HEALTH_CHECK_ENDPOINT)) {
                log.info("no valid JWT token found, uri: {}", requestURI);
            }
        }

        filterChain.doFilter(request, response);
    }
```

## 동작 확인

<img width="1449" height="716" alt="스크린샷 2025-08-08 오후 7 48 06" src="https://github.com/user-attachments/assets/ec3cd38a-fe93-4ff3-97b2-a7b8e53b7a51" />

<img width="1413" height="906" alt="스크린샷 2025-08-08 오후 7 49 08" src="https://github.com/user-attachments/assets/2d470313-7d3f-4358-b50e-93593116d6d9" />
## 💬 리뷰 요구사항(선택)

x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * JWT 토큰 만료 및 인증 관련 예외 처리가 세분화되어, 만료된 토큰에 대한 별도의 예외가 추가되었습니다.
  * 토큰 재발급 및 헬스 체크 엔드포인트가 상수로 추가되었습니다.

* **버그 수정**
  * 토큰 예외 필터에서 불필요한 공백 라인이 제거되었습니다.

* **리팩터**
  * 토큰 유효성 검사 시 예외 처리 방식이 개선되어, 사전 정의된 예외 인스턴스를 사용하도록 변경되었습니다.
  * 인증 없이 허용되는 POST 경로가 `/api/v1/tokens/**`로 확장되었습니다.

* **스타일**
  * 일부 파일에 줄바꿈 등 코드 스타일이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->