### PR TITLE
[MEDI-69] monitoring server error by webhook

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	// AWS S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	// feign client
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -64,6 +66,11 @@ dependencies {
 
 }
 
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:2025.0.0"
+	}
+}
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/java/com/my_medi/MyMediApplication.java
+++ b/src/main/java/com/my_medi/MyMediApplication.java
@@ -2,10 +2,8 @@ package com.my_medi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
-@EnableFeignClients(basePackages = "com.my_medi.infra.discord.client")
 public class MyMediApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/my_medi/MyMediApplication.java
+++ b/src/main/java/com/my_medi/MyMediApplication.java
@@ -2,8 +2,10 @@ package com.my_medi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients(basePackages = "com.my_medi.infra.discord.client")
 public class MyMediApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/my_medi/api/common/advice/ExceptionAdvice.java
+++ b/src/main/java/com/my_medi/api/common/advice/ExceptionAdvice.java
@@ -65,6 +65,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     public ResponseEntity<Object> exception(Exception e, WebRequest request) {
         e.printStackTrace();
 
+
         discordWebhookService.sendErrorMessage(e, request);
 
         return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY,

--- a/src/main/java/com/my_medi/api/common/advice/ExceptionAdvice.java
+++ b/src/main/java/com/my_medi/api/common/advice/ExceptionAdvice.java
@@ -4,11 +4,13 @@ import com.my_medi.api.common.dto.ApiResponseDto;
 import com.my_medi.common.exception.ErrorStatus;
 import com.my_medi.common.exception.GeneralException;
 import com.my_medi.common.exception.Reason;
-import com.my_medi.security.exception.JwtAuthenticationException;
+import com.my_medi.infra.discord.service.DiscordWebhookService;
 import io.swagger.v3.oas.annotations.Hidden;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -25,9 +27,12 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
+@Slf4j
 @Hidden
+@RequiredArgsConstructor
 @RestControllerAdvice(annotations = {RestController.class})
 public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+    private final DiscordWebhookService discordWebhookService;
 
     @ExceptionHandler
     public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
@@ -59,6 +64,8 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler
     public ResponseEntity<Object> exception(Exception e, WebRequest request) {
         e.printStackTrace();
+
+        discordWebhookService.sendErrorMessage(e, request);
 
         return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY,
                 ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(), request, e.getMessage());

--- a/src/main/java/com/my_medi/api/common/controller/TestApiController.java
+++ b/src/main/java/com/my_medi/api/common/controller/TestApiController.java
@@ -5,17 +5,25 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.logging.Logger;
+
+@Slf4j
 @Tag(name = "테스트 용 API")
 @RestController
 @RequestMapping("/api/v1/test")
 @RequiredArgsConstructor
 public class TestApiController {
+
+    @Value("${discord.webhook.url}")
+    private String webhook;
 
     @GetMapping
     public TestDto test(@RequestParam String message) {
@@ -29,6 +37,11 @@ public class TestApiController {
         return ApiResponseDto.onSuccess(HttpStatus.OK.toString());
     }
 
+    @GetMapping("/error")
+    public ApiResponseDto<String> error() {
+        log.info("web hook :{}, error", webhook);
+        throw new NullPointerException();
+    }
 
     @Getter
     private class TestDto{

--- a/src/main/java/com/my_medi/common/util/DiscordMessageUtil.java
+++ b/src/main/java/com/my_medi/common/util/DiscordMessageUtil.java
@@ -1,5 +1,15 @@
 package com.my_medi.common.util;
 
+import com.my_medi.infra.discord.dto.DiscordWebhookErrorMessage;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class DiscordMessageUtil {
     public static int getColorByPriority(String priority) {
         switch (priority.toUpperCase()) {
@@ -26,5 +36,47 @@ public class DiscordMessageUtil {
             case "NEW_FEATURE": return "✨";
             default: return "📝";
         }
+    }
+
+    public static DiscordWebhookErrorMessage createMessage(Exception e, WebRequest request) {
+        return DiscordWebhookErrorMessage.builder()
+                .content("# 🚨 에러 발생 비이이이이사아아아앙")
+                .embeds(
+                        List.of(
+                                DiscordWebhookErrorMessage.Embed.builder()
+                                        .title("ℹ️ 에러 정보")
+                                        .description(
+                                                "### 🕖 발생 시간\n"
+                                                        + LocalDateTime.now()
+                                                        + "\n"
+                                                        + "### 🔗 요청 URL\n"
+                                                        + createRequestFullPath(request)
+                                                        + "\n"
+                                                        + "### 📄 Stack Trace\n"
+                                                        + "```\n"
+                                                        + getStackTrace(e).substring(0, 1000)
+                                                        + "\n```")
+                                        .build()
+                        )
+                )
+                .build();
+    }
+
+    private static String createRequestFullPath(WebRequest webRequest) {
+        HttpServletRequest request = ((ServletWebRequest) webRequest).getRequest();
+        String fullPath = request.getMethod() + " " + request.getRequestURL();
+
+        String queryString = request.getQueryString();
+        if (queryString != null) {
+            fullPath += "?" + queryString;
+        }
+
+        return fullPath;
+    }
+
+    private static String getStackTrace(Exception e) {
+        StringWriter stringWriter = new StringWriter();
+        e.printStackTrace(new PrintWriter(stringWriter));
+        return stringWriter.toString();
     }
 }

--- a/src/main/java/com/my_medi/infra/discord/client/DiscordClient.java
+++ b/src/main/java/com/my_medi/infra/discord/client/DiscordClient.java
@@ -1,0 +1,17 @@
+package com.my_medi.infra.discord.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import com.my_medi.infra.discord.dto.DiscordWebhookErrorMessage;
+import com.my_medi.infra.discord.config.DiscordFeignConfiguration;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(
+        name = "discord-client",
+        url = "${discord.webhook.error}",
+        configuration = DiscordFeignConfiguration.class
+)
+public interface DiscordClient {
+    @PostMapping
+    void sendAlarm(@RequestBody DiscordWebhookErrorMessage message);
+}

--- a/src/main/java/com/my_medi/infra/discord/client/DiscordClient.java
+++ b/src/main/java/com/my_medi/infra/discord/client/DiscordClient.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(
         name = "discord-client",
-        url = "${discord.webhook.error}",
+        url = "${DISCORD_ERROR}",
         configuration = DiscordFeignConfiguration.class
 )
 public interface DiscordClient {

--- a/src/main/java/com/my_medi/infra/discord/client/DiscordClient.java
+++ b/src/main/java/com/my_medi/infra/discord/client/DiscordClient.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(
         name = "discord-client",
-        url = "${DISCORD_ERROR}",
+        url = "${discord.webhook.error}",
         configuration = DiscordFeignConfiguration.class
 )
 public interface DiscordClient {

--- a/src/main/java/com/my_medi/infra/discord/config/DiscordFeignConfiguration.java
+++ b/src/main/java/com/my_medi/infra/discord/config/DiscordFeignConfiguration.java
@@ -1,0 +1,30 @@
+package com.my_medi.infra.discord.config;
+
+import feign.FeignException;
+import feign.Logger;
+import feign.RequestInterceptor;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Bean;
+
+@Configuration
+public class DiscordFeignConfiguration {
+
+    @Bean
+    Logger.Level feignLoggerLevel() { return Logger.Level.FULL; }
+
+    @Bean
+    public ErrorDecoder discordErrorDecoder() {
+        return new ErrorDecoder.Default(); // 기본 동작: 상태코드 기반 예외 생성
+    }
+
+    @Bean
+    public RequestInterceptor jsonHeaders() {
+        return tpl -> {
+            tpl.header("Content-Type", "application/json; charset=UTF-8");
+            tpl.header("Accept", "application/json");
+        };
+    }
+}
+
+

--- a/src/main/java/com/my_medi/infra/discord/config/DiscordFeignConfiguration.java
+++ b/src/main/java/com/my_medi/infra/discord/config/DiscordFeignConfiguration.java
@@ -1,23 +1,24 @@
 package com.my_medi.infra.discord.config;
 
-import feign.FeignException;
 import feign.Logger;
 import feign.RequestInterceptor;
 import feign.codec.ErrorDecoder;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+
 
 @Configuration
 public class DiscordFeignConfiguration {
-
+    @Profile("deploy")
     @Bean
     Logger.Level feignLoggerLevel() { return Logger.Level.FULL; }
-
+    @Profile("deploy")
     @Bean
     public ErrorDecoder discordErrorDecoder() {
         return new ErrorDecoder.Default(); // 기본 동작: 상태코드 기반 예외 생성
     }
-
+    @Profile("deploy")
     @Bean
     public RequestInterceptor jsonHeaders() {
         return tpl -> {

--- a/src/main/java/com/my_medi/infra/discord/config/DiscordFeignConfiguration.java
+++ b/src/main/java/com/my_medi/infra/discord/config/DiscordFeignConfiguration.java
@@ -1,23 +1,30 @@
 package com.my_medi.infra.discord.config;
 
+import com.my_medi.infra.discord.client.DiscordClient;
 import feign.Logger;
 import feign.RequestInterceptor;
 import feign.codec.ErrorDecoder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
 
 
 @Configuration
+@ConditionalOnProperty(prefix = "discord.alert", name = "enabled", havingValue = "true")
+@EnableFeignClients(clients = DiscordClient.class)
 public class DiscordFeignConfiguration {
     @Profile("deploy")
     @Bean
     Logger.Level feignLoggerLevel() { return Logger.Level.FULL; }
+
     @Profile("deploy")
     @Bean
     public ErrorDecoder discordErrorDecoder() {
         return new ErrorDecoder.Default(); // 기본 동작: 상태코드 기반 예외 생성
     }
+
     @Profile("deploy")
     @Bean
     public RequestInterceptor jsonHeaders() {

--- a/src/main/java/com/my_medi/infra/discord/dto/ApiModificationRequest.java
+++ b/src/main/java/com/my_medi/infra/discord/dto/ApiModificationRequest.java
@@ -12,5 +12,4 @@ public class ApiModificationRequest {
     private String requesterName;
     private String priority; // HIGH, MEDIUM, LOW
     private String requestType; // MODIFICATION, BUG_FIX, NEW_FEATURE
-
 }

--- a/src/main/java/com/my_medi/infra/discord/dto/DiscordWebhookErrorMessage.java
+++ b/src/main/java/com/my_medi/infra/discord/dto/DiscordWebhookErrorMessage.java
@@ -1,0 +1,23 @@
+package com.my_medi.infra.discord.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class DiscordWebhookErrorMessage {
+    private String content;
+    private List<Embed> embeds;
+
+    @Builder
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @Getter
+    public static class Embed {
+        private String title;
+        private String description;
+    }
+}

--- a/src/main/java/com/my_medi/infra/discord/service/DiscordWebhookService.java
+++ b/src/main/java/com/my_medi/infra/discord/service/DiscordWebhookService.java
@@ -2,8 +2,9 @@ package com.my_medi.infra.discord.service;
 
 import com.my_medi.infra.discord.dto.ApiModificationRequest;
 import io.swagger.v3.oas.models.PathItem;
-import org.springframework.http.HttpMethod;
+import org.springframework.web.context.request.WebRequest;
 
 public interface DiscordWebhookService {
     void sendApiModificationRequest(String apiEndpoint, PathItem.HttpMethod httpMethod, ApiModificationRequest request);
+    void sendErrorMessage(Exception e, WebRequest request);
 }

--- a/src/main/java/com/my_medi/infra/discord/service/DiscordWebhookServiceImpl.java
+++ b/src/main/java/com/my_medi/infra/discord/service/DiscordWebhookServiceImpl.java
@@ -24,7 +24,6 @@ import static com.my_medi.common.util.DiscordMessageUtil.*;
 @Service
 @RequiredArgsConstructor
 public class DiscordWebhookServiceImpl implements DiscordWebhookService{
-    private final DiscordWebhookService discordWebhookService;
 
     private final Environment env;
     private final RestTemplate restTemplate;

--- a/src/main/java/com/my_medi/infra/discord/service/DiscordWebhookServiceImpl.java
+++ b/src/main/java/com/my_medi/infra/discord/service/DiscordWebhookServiceImpl.java
@@ -2,11 +2,8 @@ package com.my_medi.infra.discord.service;
 
 import com.my_medi.infra.discord.client.DiscordClient;
 import com.my_medi.infra.discord.dto.ApiModificationRequest;
-import com.my_medi.infra.discord.dto.DiscordWebhookErrorMessage;
-import com.my_medi.infra.discord.dto.DiscordWebhookErrorMessage.Embed;
 import com.my_medi.infra.discord.dto.DiscordWebhookMessage;
 import io.swagger.v3.oas.models.PathItem;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpEntity;
@@ -15,11 +12,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -30,6 +24,7 @@ import static com.my_medi.common.util.DiscordMessageUtil.*;
 @Service
 @RequiredArgsConstructor
 public class DiscordWebhookServiceImpl implements DiscordWebhookService{
+    private final DiscordWebhookService discordWebhookService;
 
     private final Environment env;
     private final RestTemplate restTemplate;
@@ -87,47 +82,5 @@ public class DiscordWebhookServiceImpl implements DiscordWebhookService{
     @Override
     public void sendErrorMessage(Exception e, WebRequest request) {
         discordClient.sendAlarm(createMessage(e, request));
-    }
-
-    private DiscordWebhookErrorMessage createMessage(Exception e, WebRequest request) {
-        return DiscordWebhookErrorMessage.builder()
-                .content("# 🚨 에러 발생 비이이이이사아아아앙")
-                .embeds(
-                        List.of(
-                                Embed.builder()
-                                        .title("ℹ️ 에러 정보")
-                                        .description(
-                                                "### 🕖 발생 시간\n"
-                                                        + LocalDateTime.now()
-                                                        + "\n"
-                                                        + "### 🔗 요청 URL\n"
-                                                        + createRequestFullPath(request)
-                                                        + "\n"
-                                                        + "### 📄 Stack Trace\n"
-                                                        + "```\n"
-                                                        + getStackTrace(e).substring(0, 1000)
-                                                        + "\n```")
-                                        .build()
-                        )
-                )
-                .build();
-    }
-
-    private String createRequestFullPath(WebRequest webRequest) {
-        HttpServletRequest request = ((ServletWebRequest) webRequest).getRequest();
-        String fullPath = request.getMethod() + " " + request.getRequestURL();
-
-        String queryString = request.getQueryString();
-        if (queryString != null) {
-            fullPath += "?" + queryString;
-        }
-
-        return fullPath;
-    }
-
-    private String getStackTrace(Exception e) {
-        StringWriter stringWriter = new StringWriter();
-        e.printStackTrace(new PrintWriter(stringWriter));
-        return stringWriter.toString();
     }
 }

--- a/src/main/java/com/my_medi/infra/discord/service/DiscordWebhookServiceImpl.java
+++ b/src/main/java/com/my_medi/infra/discord/service/DiscordWebhookServiceImpl.java
@@ -5,6 +5,7 @@ import com.my_medi.infra.discord.dto.ApiModificationRequest;
 import com.my_medi.infra.discord.dto.DiscordWebhookMessage;
 import io.swagger.v3.oas.models.PathItem;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -23,6 +24,7 @@ import static com.my_medi.common.util.DiscordMessageUtil.*;
 
 @Service
 @RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "discord.alert", name = "enabled", havingValue = "true")
 public class DiscordWebhookServiceImpl implements DiscordWebhookService{
 
     private final Environment env;

--- a/src/main/java/com/my_medi/infra/discord/service/DiscordWebhookServiceImpl.java
+++ b/src/main/java/com/my_medi/infra/discord/service/DiscordWebhookServiceImpl.java
@@ -1,8 +1,12 @@
 package com.my_medi.infra.discord.service;
 
+import com.my_medi.infra.discord.client.DiscordClient;
 import com.my_medi.infra.discord.dto.ApiModificationRequest;
+import com.my_medi.infra.discord.dto.DiscordWebhookErrorMessage;
+import com.my_medi.infra.discord.dto.DiscordWebhookErrorMessage.Embed;
 import com.my_medi.infra.discord.dto.DiscordWebhookMessage;
 import io.swagger.v3.oas.models.PathItem;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpEntity;
@@ -11,7 +15,11 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -75,4 +83,51 @@ public class DiscordWebhookServiceImpl implements DiscordWebhookService{
         return message;
     }
 
+    private final DiscordClient discordClient;
+    @Override
+    public void sendErrorMessage(Exception e, WebRequest request) {
+        discordClient.sendAlarm(createMessage(e, request));
+    }
+
+    private DiscordWebhookErrorMessage createMessage(Exception e, WebRequest request) {
+        return DiscordWebhookErrorMessage.builder()
+                .content("# 🚨 에러 발생 비이이이이사아아아앙")
+                .embeds(
+                        List.of(
+                                Embed.builder()
+                                        .title("ℹ️ 에러 정보")
+                                        .description(
+                                                "### 🕖 발생 시간\n"
+                                                        + LocalDateTime.now()
+                                                        + "\n"
+                                                        + "### 🔗 요청 URL\n"
+                                                        + createRequestFullPath(request)
+                                                        + "\n"
+                                                        + "### 📄 Stack Trace\n"
+                                                        + "```\n"
+                                                        + getStackTrace(e).substring(0, 1000)
+                                                        + "\n```")
+                                        .build()
+                        )
+                )
+                .build();
+    }
+
+    private String createRequestFullPath(WebRequest webRequest) {
+        HttpServletRequest request = ((ServletWebRequest) webRequest).getRequest();
+        String fullPath = request.getMethod() + " " + request.getRequestURL();
+
+        String queryString = request.getQueryString();
+        if (queryString != null) {
+            fullPath += "?" + queryString;
+        }
+
+        return fullPath;
+    }
+
+    private String getStackTrace(Exception e) {
+        StringWriter stringWriter = new StringWriter();
+        e.printStackTrace(new PrintWriter(stringWriter));
+        return stringWriter.toString();
+    }
 }

--- a/src/main/java/com/my_medi/infra/discord/service/DiscordWebhookServiceNoop.java
+++ b/src/main/java/com/my_medi/infra/discord/service/DiscordWebhookServiceNoop.java
@@ -1,0 +1,14 @@
+package com.my_medi.infra.discord.service;
+
+import com.my_medi.infra.discord.dto.ApiModificationRequest;
+import io.swagger.v3.oas.models.PathItem;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.WebRequest;
+
+@Service
+@ConditionalOnProperty(prefix = "discord.alert", name = "enabled", havingValue = "false", matchIfMissing = true)
+public class DiscordWebhookServiceNoop implements DiscordWebhookService {
+    @Override public void sendApiModificationRequest(String api, PathItem.HttpMethod m, ApiModificationRequest r) {}
+    @Override public void sendErrorMessage(Exception e, WebRequest req) {}
+}

--- a/src/main/java/com/my_medi/security/config/SecurityConfig.java
+++ b/src/main/java/com/my_medi/security/config/SecurityConfig.java
@@ -84,7 +84,7 @@ public class SecurityConfig {
     private String[] permitAllGetPaths() {
         return new String[]{
                 "/api/v1/examples/**",
-                "/api/v1/test",
+                "/api/v1/test/**",
                 "/api/v1/test/health-check",
                 "/api/v1/examples/user",
                 "/api/v1/examples/global"

--- a/src/main/resources/application-deploy.yml
+++ b/src/main/resources/application-deploy.yml
@@ -31,6 +31,8 @@ spring:
       port: 6379
 
   ### discord webhook ###
-  discord:
-    webhook:
-      error: ${DISCORD_ERROR}
+discord:
+  alert:
+    enabled: true
+  webhook:
+    error: ${DISCORD_ERROR}

--- a/src/main/resources/application-deploy.yml
+++ b/src/main/resources/application-deploy.yml
@@ -29,3 +29,8 @@ spring:
     redis:
       host: redis
       port: 6379
+
+  ### discord webhook ###
+  discord:
+    webhook:
+      error: ${DISCORD_ERROR}

--- a/src/main/resources/application-han.yml
+++ b/src/main/resources/application-han.yml
@@ -40,7 +40,6 @@ spring:
       host: localhost
       port: 6379
 
-  ### discord webhook ###
-  discord:
-    webhook:
-      error: ""
+discord:
+  alert:
+    enabled: false

--- a/src/main/resources/application-han.yml
+++ b/src/main/resources/application-han.yml
@@ -39,3 +39,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+  ### discord webhook ###
+  discord:
+    webhook:
+      error: ""

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -29,3 +29,7 @@ spring:
       host: localhost
       port: 6379
 
+  ### discord webhook ###
+  discord:
+    webhook:
+      error: ""

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -29,7 +29,6 @@ spring:
       host: localhost
       port: 6379
 
-  ### discord webhook ###
-  discord:
-    webhook:
-      error: ""
+discord:
+  alert:
+    enabled: false


### PR DESCRIPTION
## #️⃣ 요약 설명

## 📝 작업 내용

Discord webhook을 사용하여 500 error message를 discord channel에 보내는 기능

```java
private final DiscordClient discordClient;
    @Override
    public void sendErrorMessage(Exception e, WebRequest request) {
        discordClient.sendAlarm(createMessage(e, request));
    }

    private DiscordWebhookErrorMessage createMessage(Exception e, WebRequest request) {
        return DiscordWebhookErrorMessage.builder()
                .content("# 🚨 에러 발생 비이이이이사아아아앙")
                .embeds(
                        List.of(
                                Embed.builder()
                                        .title("ℹ️ 에러 정보")
                                        .description(
                                                "### 🕖 발생 시간\n"
                                                        + LocalDateTime.now()
                                                        + "\n"
                                                        + "### 🔗 요청 URL\n"
                                                        + createRequestFullPath(request)
                                                        + "\n"
                                                        + "### 📄 Stack Trace\n"
                                                        + "```\n"
                                                        + getStackTrace(e).substring(0, 1000)
                                                        + "\n```")
                                        .build()
                        )
                )
                .build();
    }

    private String createRequestFullPath(WebRequest webRequest) {
        HttpServletRequest request = ((ServletWebRequest) webRequest).getRequest();
        String fullPath = request.getMethod() + " " + request.getRequestURL();

        String queryString = request.getQueryString();
        if (queryString != null) {
            fullPath += "?" + queryString;
        }

        return fullPath;
    }

    private String getStackTrace(Exception e) {
        StringWriter stringWriter = new StringWriter();
        e.printStackTrace(new PrintWriter(stringWriter));
        return stringWriter.toString();
    }
```

## 동작 확인

<img width="772" height="687" alt="image" src="https://github.com/user-attachments/assets/b08c4a56-6335-4b32-a423-6fff7e89674d" />


## 💬 리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 애플리케이션 오류 발생 시 Discord 웹훅으로 알림 전송 지원
  - 테스트용 오류 엔드포인트 추가: GET /api/v1/test/error
- Security
  - 공개 GET 경로를 /api/v1/test/** 로 확대 허용
- Configuration
  - 새 설정 추가: discord.alert.enabled, discord.webhook.error
  - 프로필별 기본값 제공 (local/han: 비활성, deploy: 활성)
- Chores
  - OpenFeign 도입 및 Spring Cloud BOM으로 의존성 정합성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->