### PR TITLE
[MEDI-105] feat: validate id and nickname is unique

### DIFF
--- a/src/main/java/com/my_medi/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/my_medi/domain/member/repository/MemberRepository.java
@@ -10,4 +10,8 @@ public interface MemberRepository extends JpaRepository<Member,Long> {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByLoginId(String loginId);
+
+    boolean existsByLoginId(String loginId);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/my_medi/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/my_medi/domain/member/service/MemberQueryService.java
@@ -7,4 +7,8 @@ public interface MemberQueryService {
     Member getByKakaoEmail(String email);
 
     Member getByLoginId(String loginId);
+
+    boolean validateExistNickname(String nickname);
+
+    boolean validateExistLoginId(String loginId);
 }

--- a/src/main/java/com/my_medi/domain/member/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/member/service/MemberQueryServiceImpl.java
@@ -33,5 +33,15 @@ public class MemberQueryServiceImpl implements MemberQueryService{
         return memberRepository.findByLoginId(loginId)
                 .orElseThrow(()->ExpertHandler.NOT_FOUND);
     }
+
+    @Override
+    public boolean validateExistNickname(String nickname) {
+        return memberRepository.existsByNickname(nickname);
+    }
+
+    @Override
+    public boolean validateExistLoginId(String loginId) {
+        return memberRepository.existsByLoginId(loginId);
+    }
 }
 

--- a/src/main/java/com/my_medi/security/controller/TokenApiController.java
+++ b/src/main/java/com/my_medi/security/controller/TokenApiController.java
@@ -1,11 +1,11 @@
 package com.my_medi.security.controller;
 
 import com.my_medi.api.common.dto.ApiResponseDto;
+import com.my_medi.domain.member.repository.MemberRepository;
 import com.my_medi.security.jwt.dto.JwtToken;
 import com.my_medi.security.jwt.dto.MemberLoginRequestDto;
 import com.my_medi.security.jwt.service.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class TokenApiController {
 
     private final TokenService tokenService;
+    private final MemberRepository memberRepository;
 
     @Operation(summary = "이메일로 JWT 토큰 발급")
     @PostMapping("/login")
@@ -30,5 +31,19 @@ public class TokenApiController {
     @PostMapping("/reissue")
     public ApiResponseDto<JwtToken> issueToken(@RequestParam String refresh) {
         return ApiResponseDto.onSuccess(tokenService.issueTokens(refresh));
+    }
+
+    @Operation(summary = "id unique 검증")
+    @PostMapping("/id")
+    public ApiResponseDto<Boolean> idValidator(@RequestParam String memberId) {
+        boolean isValid = !memberRepository.existsByLoginId(memberId);
+        return ApiResponseDto.onSuccess(isValid);
+    }
+
+    @Operation(summary = "nickname unique 검증")
+    @PostMapping("/nickname")
+    public ApiResponseDto<Boolean> nicknameValidator(@RequestParam String nickname) {
+        boolean isValid = !memberRepository.existsByNickname(nickname);
+        return ApiResponseDto.onSuccess(isValid);
     }
 }

--- a/src/main/java/com/my_medi/security/controller/TokenApiController.java
+++ b/src/main/java/com/my_medi/security/controller/TokenApiController.java
@@ -2,6 +2,7 @@ package com.my_medi.security.controller;
 
 import com.my_medi.api.common.dto.ApiResponseDto;
 import com.my_medi.domain.member.repository.MemberRepository;
+import com.my_medi.domain.member.service.MemberQueryService;
 import com.my_medi.security.jwt.dto.JwtToken;
 import com.my_medi.security.jwt.dto.MemberLoginRequestDto;
 import com.my_medi.security.jwt.service.TokenService;
@@ -19,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class TokenApiController {
 
     private final TokenService tokenService;
-    private final MemberRepository memberRepository;
+    private final MemberQueryService memberQueryService;
 
     @Operation(summary = "이메일로 JWT 토큰 발급")
     @PostMapping("/login")
@@ -34,16 +35,14 @@ public class TokenApiController {
     }
 
     @Operation(summary = "id unique 검증")
-    @PostMapping("/id")
-    public ApiResponseDto<Boolean> idValidator(@RequestParam String memberId) {
-        boolean isValid = !memberRepository.existsByLoginId(memberId);
-        return ApiResponseDto.onSuccess(isValid);
+    @PostMapping("/duplication/login-id")
+    public ApiResponseDto<Boolean> idValidator(@RequestParam String loginId) {
+        return ApiResponseDto.onSuccess(memberQueryService.validateExistLoginId(loginId));
     }
 
     @Operation(summary = "nickname unique 검증")
-    @PostMapping("/nickname")
+    @PostMapping("/duplication-nickname")
     public ApiResponseDto<Boolean> nicknameValidator(@RequestParam String nickname) {
-        boolean isValid = !memberRepository.existsByNickname(nickname);
-        return ApiResponseDto.onSuccess(isValid);
+        return ApiResponseDto.onSuccess(memberQueryService.validateExistNickname(nickname));
     }
 }


### PR DESCRIPTION
## #️⃣ 요약 설명

## 📝 작업 내용

회원가입에서 입력한 id와 nickname이 unique 한지 검증하는 기능

```java
@Operation(summary = "id unique 검증")
    @PostMapping("/id")
    public ApiResponseDto<Boolean> idValidator(@RequestParam String memberId) {
        boolean isValid = !memberRepository.existsByLoginId(memberId);
        return ApiResponseDto.onSuccess(isValid);
    }

    @Operation(summary = "nickname unique 검증")
    @PostMapping("/nickname")
    public ApiResponseDto<Boolean> nicknameValidator(@RequestParam String nickname) {
        boolean isValid = !memberRepository.existsByNickname(nickname);
        return ApiResponseDto.onSuccess(isValid);
    }
```

## 동작 확인


## 💬 리뷰 요구사항(선택)

일단 id랑 nickname 따로 검증하게 했는데 별로같으면 수정하겠슴

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 회원가입 시 아이디와 닉네임의 중복 여부를 즉시 확인하는 검증 API를 추가했습니다.
  - /id 및 /nickname 엔드포인트에서 사용할 수 있으며, 중복 아님 여부를 표준 응답 형식으로 Boolean 값으로 반환합니다.
  - 응답 형식의 일관성을 유지하여 프론트엔드 실시간 유효성 검사에 활용 가능합니다.
  - 기존 로그인 및 토큰 재발급 기능에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->