### PR TITLE
[MEDI-70] refactor : mapping healthCheckData to WriteReportDto

### DIFF
--- a/src/main/java/com/my_medi/api/report/controller/UserReportApiController.java
+++ b/src/main/java/com/my_medi/api/report/controller/UserReportApiController.java
@@ -72,9 +72,10 @@ public class UserReportApiController {
 
     @Operation(summary = "GPT API를 사용하여 건강검진 이미지를 원하는 데이터대로 추출합니다.")
     @PostMapping(value = "/parsing", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponseDto<HealthReportData> parsingHealthReportImage(@RequestPart MultipartFile imageFile) {
+    public ApiResponseDto<WriteReportRequestDto> parsingHealthReportImage(@RequestPart MultipartFile imageFile) {
+        HealthReportData healthReportData = openAIService.parseHealthReport(ImageUtil.convertToByte(imageFile));
         return ApiResponseDto.onSuccess(
-                openAIService.parseHealthReport(ImageUtil.convertToByte(imageFile))
+                ReportConverter.toWriteReportRequestDto(healthReportData)
         );
     }
 

--- a/src/main/java/com/my_medi/api/report/mapper/ReportConverter.java
+++ b/src/main/java/com/my_medi/api/report/mapper/ReportConverter.java
@@ -8,12 +8,21 @@ import com.my_medi.api.report.dto.ReportResponseDto.UserReportDto;
 import com.my_medi.api.report.dto.*;
 import com.my_medi.common.util.BirthDateUtil;
 
+import com.my_medi.common.util.EnumConvertUtil;
 import com.my_medi.domain.healthCheckup.entity.HealthCheckup;
 import com.my_medi.domain.member.entity.Gender;
 import com.my_medi.domain.report.entity.*;
+import com.my_medi.domain.report.enums.BloodPressureStatus;
+import com.my_medi.domain.report.enums.ImagingTestStatus;
+import com.my_medi.domain.report.enums.UrineTestStatus;
+import com.my_medi.domain.report.enums.interview.LifestyleHabitsStatus;
+import com.my_medi.domain.report.enums.interview.PositiveNegativeStatus;
+import com.my_medi.infra.gpt.dto.HealthReportData;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 
 import static com.my_medi.api.healthCheckup.mapper.HealthCheckupMapper.*;
@@ -352,6 +361,62 @@ public class ReportConverter {
                                 .build()
                 )
                 .build();
+    }
+
+    public static WriteReportRequestDto toWriteReportRequestDto(HealthReportData healthReportData) {
+        return WriteReportRequestDto.builder()
+                .hospitalName(null)
+                .checkupDate(healthReportData.getCheckupDate())
+                .measurementDto(
+                        MeasurementDto.builder()
+                                .height(healthReportData.getMeasurement().getHeight())
+                                .weight(healthReportData.getMeasurement().getWeight())
+                                .bmi(healthReportData.getMeasurement().getBmi())
+                                .waist(healthReportData.getMeasurement().getWaistCircumference())
+                                .vision(healthReportData.getMeasurement().getVision())
+                                .build()
+                )
+                .bloodPressureDto(
+                        BloodPressureDto.builder()
+                                .systolic(healthReportData.getBloodPressure().getSystolic())
+                                .diastolic(healthReportData.getBloodPressure().getDiastolic())
+                                .bloodPressureStatus(EnumConvertUtil.convertOrNull(BloodPressureStatus.class, healthReportData.getBloodPressure().getStatus()))
+                                .build()
+                )
+                .bloodTestDto(
+                        BloodTestDto.builder()
+                                //간장질환
+                                .alt(healthReportData.getBloodTest().getAlt())
+                                .ast(healthReportData.getBloodTest().getAst())
+                                // 이상지혈증
+                                .totalCholesterol(roundOrNull(healthReportData.getBloodTest().getTotalCholesterol()))
+                                .hdl(roundOrNull(healthReportData.getBloodTest().getHdlCholesterol()))
+                                .ldl(roundOrNull(healthReportData.getBloodTest().getLdlCholesterol()))
+                                .triglyceride(roundOrNull(healthReportData.getBloodTest().getTriglycerides()))
+                                //혈색소
+                                .hemoglobin(healthReportData.getBloodTest().getHemoglobin())
+                                //당뇨병
+                                .fastingGlucose(roundOrNull(healthReportData.getBloodTest().getGlucose()))
+                                //신장질환
+                                .creatinine(healthReportData.getBloodTest().getCreatinine())
+                                .egfr(roundOrNull(healthReportData.getBloodTest().getEgfr()))
+                                .build()
+                )
+                .urineTestDto(
+                        UrineTestDto.builder()
+                                .urineTestStatus(EnumConvertUtil.convertOrNull(UrineTestStatus.class, healthReportData.getUrineTest().getProtein()))
+                                .build()
+                )
+                .imagingTestDto(
+                        ImagingTestDto.builder()
+                                .imagingTestStatus(EnumConvertUtil.convertOrNull(ImagingTestStatus.class, healthReportData.getImagingTest().getChestXray()))
+                                .build()
+                )
+                .build();
+    }
+
+    private static Integer roundOrNull(Double value) {
+        return value != null ? (int) Math.round(value) : null;
     }
 
 

--- a/src/main/java/com/my_medi/common/consts/Prompt.java
+++ b/src/main/java/com/my_medi/common/consts/Prompt.java
@@ -42,30 +42,18 @@ public class Prompt {
                 "gammaGtp": "감마지티피(IU/L, 숫자만)"
               },
               "urineTest": {
-                "protein": "요단백",
-                "glucose": "요당"
+                "protein": "정상 | 경계 | 단백뇨 의심",
               },
               "imagingTest": {
-                "chestXray": "흉부촬영 결과",
-                "pastMedicalHistory": "과거병력",
-                "currentMedication": "복용약물"
-              },
-              "interview": {
-                "smoking": "흡연상태",
-                "drinking": "음주상태",
-                "exercise": "운동상태",
-                "familyHistory": "가족력"
-              },
-              "additionalTest": {
-                "hepatitisB": "B형간염",
-                "depression": "우울증",
-                "cognitiveFunction": "인지기능장애",
-                "osteoporosis": "골밀도검사",
-                "additionalNotes": "기타 추가 검사"
+                "chestXray": "정상 | 비활동성 폐결핵 | 질환 의심 | 기타",
               }
             }
             
-            숫자 값은 반드시 숫자만 추출하고, 없는 정보는 null로 표시해주세요.
+            규칙:
+            - 'urineTest.protein'과 'imagingTest.chestXray'는 **반드시 문자열(String)** 로 반환합니다.
+            - 각각 위에 제시된 옵션 문자열 중 하나만 반환하세요. (예: "정상")
+            - 해당 정보를 확정할 수 없으면 null을 사용하세요.
+            - 숫자 값은 반드시 숫자만 추출하고, 없는 정보는 null로 표시해주세요.
             """;
 
     public static String HEALTH_TERM_PROMPT = """

--- a/src/main/java/com/my_medi/common/util/EnumConvertUtil.java
+++ b/src/main/java/com/my_medi/common/util/EnumConvertUtil.java
@@ -15,6 +15,13 @@ public class EnumConvertUtil {
                 .orElseThrow(() -> new RuntimeException("Key not found in " + enumClass.getSimpleName()));
     }
 
+    public static <E extends Enum<E> & KeyedEnum> E convertOrNull(Class<E> enumClass, String key) {
+        return Arrays.stream(enumClass.getEnumConstants())
+                .filter(e -> e.getKey().equals(key))
+                .findFirst()
+                .orElse(null);
+    }
+
     public static Specialty getRandomSpecialty() {
         Specialty[] values = Specialty.values();
         int randomIndex = ThreadLocalRandom.current().nextInt(values.length);

--- a/src/main/java/com/my_medi/common/util/ParseUtil.java
+++ b/src/main/java/com/my_medi/common/util/ParseUtil.java
@@ -94,34 +94,12 @@ public class ParseUtil {
     public static HealthReportData.UrineTestData parseUrineTest(JsonNode node) {
         return HealthReportData.UrineTestData.builder()
                 .protein(parseString(node.path("protein")))
-                .glucose(parseString(node.path("glucose")))
                 .build();
     }
 
     public static HealthReportData.ImagingTestData parseImagingTest(JsonNode node) {
         return HealthReportData.ImagingTestData.builder()
                 .chestXray(parseString(node.path("chestXray")))
-                .pastMedicalHistory(parseString(node.path("pastMedicalHistory")))
-                .currentMedication(parseString(node.path("currentMedication")))
-                .build();
-    }
-
-    public static HealthReportData.InterviewData parseInterview(JsonNode node) {
-        return HealthReportData.InterviewData.builder()
-                .smoking(parseString(node.path("smoking")))
-                .drinking(parseString(node.path("drinking")))
-                .exercise(parseString(node.path("exercise")))
-                .familyHistory(parseString(node.path("familyHistory")))
-                .build();
-    }
-
-    public static HealthReportData.AdditionalTestData parseAdditionalTest(JsonNode node) {
-        return HealthReportData.AdditionalTestData.builder()
-                .hepatitisB(parseString(node.path("hepatitisB")))
-                .depression(parseString(node.path("depression")))
-                .cognitiveFunction(parseString(node.path("cognitiveFunction")))
-                .osteoporosis(parseString(node.path("osteoporosis")))
-                .additionalNotes(parseString(node.path("additionalNotes")))
                 .build();
     }
 

--- a/src/main/java/com/my_medi/domain/report/enums/BloodPressureStatus.java
+++ b/src/main/java/com/my_medi/domain/report/enums/BloodPressureStatus.java
@@ -1,11 +1,12 @@
 package com.my_medi.domain.report.enums;
 
+import com.my_medi.common.interfaces.KeyedEnum;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum BloodPressureStatus {
+public enum BloodPressureStatus implements KeyedEnum {
     NORMAL("정상"),
     PREHYPERTENSION("고혈압 전단계"),
     HYPERTENSION("고혈압 의심"),

--- a/src/main/java/com/my_medi/domain/report/enums/ImagingTestStatus.java
+++ b/src/main/java/com/my_medi/domain/report/enums/ImagingTestStatus.java
@@ -1,11 +1,12 @@
 package com.my_medi.domain.report.enums;
 
+import com.my_medi.common.interfaces.KeyedEnum;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum ImagingTestStatus {
+public enum ImagingTestStatus implements KeyedEnum {
     NORMAL("정상"),
     INACTIVE_PULMONARY_TUBERCULOSIS("비활동성 폐결핵"),
     DISEASE("질환 의심"),

--- a/src/main/java/com/my_medi/domain/report/enums/UrineTestStatus.java
+++ b/src/main/java/com/my_medi/domain/report/enums/UrineTestStatus.java
@@ -1,11 +1,12 @@
 package com.my_medi.domain.report.enums;
 
+import com.my_medi.common.interfaces.KeyedEnum;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum UrineTestStatus {
+public enum UrineTestStatus implements KeyedEnum {
     NORMAL("정상"),
     BORDERLINE("경계"),
     PROTEINURIA("단백뇨 의심");

--- a/src/main/java/com/my_medi/infra/gpt/dto/HealthReportData.java
+++ b/src/main/java/com/my_medi/infra/gpt/dto/HealthReportData.java
@@ -15,8 +15,6 @@ public class HealthReportData {
     private BloodTestData bloodTest;
     private UrineTestData urineTest;
     private ImagingTestData imagingTest;
-    private InterviewData interview;
-    private AdditionalTestData additionalTest;
 
     @Data
     @Builder
@@ -57,33 +55,11 @@ public class HealthReportData {
     @Builder
     public static class UrineTestData {
         private String protein;
-        private String glucose;
     }
 
     @Data
     @Builder
     public static class ImagingTestData {
         private String chestXray;
-        private String pastMedicalHistory;
-        private String currentMedication;
-    }
-
-    @Data
-    @Builder
-    public static class InterviewData {
-        private String smoking;
-        private String drinking;
-        private String exercise;
-        private String familyHistory;
-    }
-
-    @Data
-    @Builder
-    public static class AdditionalTestData {
-        private String hepatitisB;
-        private String depression;
-        private String cognitiveFunction;
-        private String osteoporosis;
-        private String additionalNotes;
     }
 }

--- a/src/main/java/com/my_medi/infra/gpt/service/OpenAIServiceImpl.java
+++ b/src/main/java/com/my_medi/infra/gpt/service/OpenAIServiceImpl.java
@@ -63,8 +63,6 @@ public class OpenAIServiceImpl implements OpenAIService {
                     .bloodTest(parseBloodTest(jsonNode.path(BLOOD_TEST)))
                     .urineTest(parseUrineTest(jsonNode.path(URINE_TEST)))
                     .imagingTest(parseImagingTest(jsonNode.path(IMAGING_TEST)))
-                    .interview(parseInterview(jsonNode.path(INTERVIEW)))
-                    .additionalTest(parseAdditionalTest(jsonNode.path(ADDITIONAL_TEST)))
                     .build();
         } catch (Exception e) {
             //TODO exception 처리


### PR DESCRIPTION
## #️⃣ 요약 설명
>이미지를 파싱한 데이터를 리포트 작성 폼과 동일하게 수정
## 📝 작업 내용
x
## 동작 확인
### 결과
~~~json
{
  "isSuccess": true,
  "code": 2000,
  "message": "성공",
  "result": {
    "hospitalName": null,
    "checkupDate": "2019-12-26",
    "measurementDto": {
      "height": 163.7,
      "weight": 55.3,
      "bmi": 20.7,
      "bmiCategory": null,
      "waist": 68,
      "waistType": null,
      "vision": "0.9/0.8",
      "hearingLeft": null,
      "hearingRight": null
    },
    "bloodPressureDto": {
      "systolic": 113,
      "diastolic": 62,
      "bloodPressureStatus": "NORMAL"
    },
    "bloodTestDto": {
      "hemoglobin": 12.3,
      "hemoglobinStatus": null,
      "fastingGlucose": 85,
      "fastingGlucoseType": null,
      "totalCholesterol": null,
      "hdl": null,
      "triglyceride": null,
      "ldl": null,
      "cholesterolStatus": null,
      "creatinine": 0.9,
      "egfr": 72,
      "renalFunctionStatus": null,
      "ast": 18,
      "alt": 9,
      "gtp": null,
      "liverFunctionStatus": null
    },
    "urineTestDto": {
      "urineTestStatus": "NORMAL"
    },
    "imagingTestDto": {
      "imagingTestStatus": "NORMAL"
    },
    "interviewDto": null,
    "hasAdditionalTest": null,
    "additionalTestDto": null
  }
}
~~~

## 💬 리뷰 요구사항(선택)

x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 건강검진 이미지 파싱 결과를 보고서 작성 요청 형식으로 반환해 입력 흐름을 간소화했습니다.
- Refactor
  - 데이터 구조 슬림화: 문진/추가검사, 요검사 포도당, 영상검사 병력·복약 정보 제거.
  - 상태값 매핑 로직을 표준화하고, 매칭 실패 시 null 처리로 안정성을 높였습니다.
  - 프롬프트 규칙 개선: 요단백·흉부촬영 결과를 지정된 옵션 문자열로 일관되게 반환하도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->