### PR TITLE
[MEDI-115] refactor consultation delete logic

### DIFF
--- a/src/main/java/com/my_medi/api/consultation/controller/UserConsultationApiController.java
+++ b/src/main/java/com/my_medi/api/consultation/controller/UserConsultationApiController.java
@@ -4,27 +4,20 @@ import com.my_medi.api.common.dto.ApiResponseDto;
 import com.my_medi.api.consultation.dto.UserConsultationDto;
 import com.my_medi.api.consultation.mapper.UserConsultationConvert;
 import com.my_medi.api.consultation.service.ConsultationUseCase;
-import com.my_medi.api.consultation.validator.ExpertAllowedToViewUserInfoValidator;
 import com.my_medi.common.annotation.AuthUser;
 import com.my_medi.domain.consultationRequest.entity.ConsultationRequest;
 import com.my_medi.domain.consultationRequest.entity.RequestStatus;
-import com.my_medi.domain.consultationRequest.exception.ConsultationRequestHandler;
 import com.my_medi.domain.consultationRequest.repository.ConsultationRequestRepository;
 import com.my_medi.domain.consultationRequest.service.ConsultationRequestCommandService;
 import com.my_medi.domain.consultationRequest.service.ConsultationRequestQueryService;
-import com.my_medi.domain.expert.entity.Expert;
-import com.my_medi.domain.expert.exception.ExpertHandler;
 import com.my_medi.domain.expert.repository.ExpertRepository;
 import com.my_medi.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.*;
 
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -84,11 +77,14 @@ public class UserConsultationApiController {
 
 
 
-    @Operation(summary = "본인이 요청한 상담을 취소합니다.")
+    @Operation(summary = "본인이 요청한 상담 또는 매칭된 상담을 취소합니다.")
     @DeleteMapping("/{consultationId}")
-    public ApiResponseDto<Long> cancelConsultation(@AuthUser User user,
-                                                   @PathVariable Long consultationId) {
-        consultationRequestCommandService.cancelRequest(consultationId, user.getId());
+    public ApiResponseDto<Long> cancelConsultation(
+            @AuthUser User user,
+            @PathVariable Long consultationId,
+            @RequestParam(defaultValue = "REQUESTED")  RequestStatus status
+    ) {
+        consultationRequestCommandService.cancelRequest(consultationId, user.getId(), status);
         return ApiResponseDto.onSuccess(consultationId);
     }
 

--- a/src/main/java/com/my_medi/domain/consultationRequest/exception/ConsultationRequestErrorStatus.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/exception/ConsultationRequestErrorStatus.java
@@ -31,7 +31,11 @@ public enum ConsultationRequestErrorStatus implements BaseErrorCode {
 
     CONSULTATION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, 4157, "해당 전문가에게 요청 가능한 상담 수를 초과했습니다."),
 
-    ALREADY_PROCESSED_CONSULTATION(HttpStatus.BAD_REQUEST, 4158, "이미 처리된 상담 요청이 있어 새로운 요청이 불가합니다.");
+    ALREADY_PROCESSED_CONSULTATION(HttpStatus.BAD_REQUEST, 4158, "이미 처리된 상담 요청이 있어 새로운 요청이 불가합니다."),
+
+    INVALID_STATUS(HttpStatus.BAD_REQUEST, 4159, "해당 상태의 상담 요청은 취소할 수 없습니다."),
+
+    REQUEST_FAILED(HttpStatus.BAD_REQUEST, 4160, "상담 요청을 취소할 수 없습니다. 존재하지 않거나, 권한이 없거나, 취소 불가능한 상태입니다.");
 
 
 

--- a/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/repository/ConsultationRequestRepository.java
@@ -82,6 +82,9 @@ public interface ConsultationRequestRepository extends JpaRepository<Consultatio
             @Param("status") RequestStatus status
     );
 
+    int deleteByIdAndUserIdAndRequestStatus(Long id, Long userId, RequestStatus status);
+
+
 
 
 

--- a/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestCommandService.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestCommandService.java
@@ -1,5 +1,6 @@
 package com.my_medi.domain.consultationRequest.service;
 
+import com.my_medi.domain.consultationRequest.entity.RequestStatus;
 import com.my_medi.domain.expert.entity.Expert;
 import com.my_medi.domain.user.entity.User;
 
@@ -9,7 +10,7 @@ public interface ConsultationRequestCommandService {
 
     Long editCommentOfRequest(Long consultationRequestId, Long userId, String comment);
 
-    void cancelRequest(Long consultationRequestId, Long userId);
+    void cancelRequest(Long consultationRequestId, Long userId, RequestStatus status);
 
     void approveConsultation(Long consultationRequestId, Expert expert);
 

--- a/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestCommandServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/consultationRequest/service/ConsultationRequestCommandServiceImpl.java
@@ -70,11 +70,15 @@ public class ConsultationRequestCommandServiceImpl implements ConsultationReques
     }
 
     @Override
-    public void cancelRequest(Long consultationRequestId, Long userId) {
+    public void cancelRequest(Long consultationRequestId, Long userId, RequestStatus status) {
         ConsultationRequest request = getRequestedConsultation(consultationRequestId);
 
-        if (!request.getUser().getId().equals(userId)) {
-            throw new ConsultationRequestHandler(ConsultationRequestErrorStatus.REQUEST_ONLY_CAN_BE_TOUCHED_BY_USER);
+        if (status == RequestStatus.REJECTED) {
+            throw new ConsultationRequestHandler(ConsultationRequestErrorStatus.INVALID_STATUS);
+        }
+
+        if (consultationRequestRepository.deleteByIdAndUserIdAndRequestStatus(consultationRequestId, userId, status) == 0) {
+            throw new ConsultationRequestHandler(ConsultationRequestErrorStatus.REQUEST_FAILED);
         }
 
         consultationRequestRepository.delete(request);


### PR DESCRIPTION
## #️⃣ 요약 설명
상담 요청 삭제 로직 수정

## 📝 작업 내용

> status parameter 추가
reject일 떄는 에러 반환
status, userId, consultationId 가 모두 일치할 때 삭제할 수 있도록 로직 수정


## 동작 확인

<img width="1470" height="956" alt="스크린샷 2025-08-15 오후 5 09 05" src="https://github.com/user-attachments/assets/4501d6a4-0fa2-496e-860b-653a8386a737" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?