### PR TITLE
[MEDI-95] notification by sse

### DIFF
--- a/src/main/java/com/my_medi/api/advice/service/AdviceUseCase.java
+++ b/src/main/java/com/my_medi/api/advice/service/AdviceUseCase.java
@@ -1,6 +1,7 @@
 package com.my_medi.api.advice.service;
 
 import com.my_medi.api.consultation.validator.ExpertAllowedToViewUserInfoValidator;
+import com.my_medi.common.annotation.UseCase;
 import com.my_medi.domain.advice.entity.Advice;
 import com.my_medi.domain.advice.exception.AdviceHandler;
 import com.my_medi.domain.advice.repository.AdviceRepository;
@@ -18,7 +19,7 @@ import org.springframework.stereotype.Service;
 import static com.my_medi.common.consts.StaticVariable.ADVICE_ID;
 import static com.my_medi.common.consts.StaticVariable.CREATED_DATE;
 
-@Service
+@UseCase
 @RequiredArgsConstructor
 public class AdviceUseCase {
     private final AdviceQueryService adviceQueryService;

--- a/src/main/java/com/my_medi/api/common/dto/NotificationEventDto.java
+++ b/src/main/java/com/my_medi/api/common/dto/NotificationEventDto.java
@@ -1,0 +1,28 @@
+package com.my_medi.api.common.dto;
+
+import com.my_medi.api.expertNotification.dto.ExpertNotificationResponseDto;
+import com.my_medi.api.expertNotification.dto.ExpertNotificationResponseDto.ExpertNotificationDto;
+import com.my_medi.api.userNotification.dto.UserNotificationResponseDto;
+import com.my_medi.api.userNotification.dto.UserNotificationResponseDto.UserNotificationDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+public class NotificationEventDto {
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    public static class UserNotificationEventDto{
+        private UserNotificationDto userNotificationDto;
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    public static class ExpertNotificationEventDto{
+        private ExpertNotificationDto expertNotificationDto;
+    }
+
+
+}

--- a/src/main/java/com/my_medi/api/common/service/SseService.java
+++ b/src/main/java/com/my_medi/api/common/service/SseService.java
@@ -1,0 +1,15 @@
+package com.my_medi.api.common.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface SseService {
+
+    SseEmitter connectUser(Long userId);
+
+    SseEmitter connectExpert(Long expertId);
+
+    void sendToUser(Long userId, Object notification);
+
+    void sendToExpert(Long expertId, Object notification);
+}

--- a/src/main/java/com/my_medi/api/common/service/SseServiceImpl.java
+++ b/src/main/java/com/my_medi/api/common/service/SseServiceImpl.java
@@ -1,0 +1,109 @@
+package com.my_medi.api.common.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SseServiceImpl implements SseService{
+    @Qualifier("userEmitters")
+    private final Map<String, SseEmitter> userEmitters;
+
+    @Qualifier("expertEmitters")
+    private final Map<String, SseEmitter> expertEmitters;
+    @Override
+    public SseEmitter connectUser(Long userId) {
+        String key = "user_" + userId;
+        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+
+        emitter.onCompletion(() -> userEmitters.remove(key));
+        emitter.onTimeout(() -> userEmitters.remove(key));
+        emitter.onError((e) -> {
+            log.error("SSE error for user {}: {}", userId, e.getMessage());
+            userEmitters.remove(key);
+        });
+
+        userEmitters.put(key, emitter);
+
+        try {
+            // 연결 확인 메시지
+            emitter.send(SseEmitter.event()
+                    .name("connected")
+                    .data("SSE 연결이 성공했습니다"));
+        } catch (IOException e) {
+            log.error("Failed to send connection message to user {}", userId, e);
+            userEmitters.remove(key);
+            emitter.completeWithError(e);
+        }
+
+        return emitter;
+    }
+
+    @Override
+    public SseEmitter connectExpert(Long expertId) {
+        String key = "expert_" + expertId;
+        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+
+        emitter.onCompletion(() -> expertEmitters.remove(key));
+        emitter.onTimeout(() -> expertEmitters.remove(key));
+        emitter.onError((e) -> {
+            log.error("SSE error for expert {}: {}", expertId, e.getMessage());
+            expertEmitters.remove(key);
+        });
+
+        expertEmitters.put(key, emitter);
+
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("connected")
+                    .data("SSE 연결이 성공했습니다"));
+        } catch (IOException e) {
+            log.error("Failed to send connection message to expert {}", expertId, e);
+            expertEmitters.remove(key);
+            emitter.completeWithError(e);
+        }
+
+        return emitter;
+    }
+
+    @Override
+    public void sendToUser(Long userId, Object notification) {
+        String key = "user_" + userId;
+        SseEmitter emitter = userEmitters.get(key);
+
+        if (emitter != null) {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("notification")
+                        .data(notification));
+            } catch (IOException e) {
+                log.error("Failed to send notification to user {}", userId, e);
+                userEmitters.remove(key);
+            }
+        }
+    }
+
+    @Override
+    public void sendToExpert(Long expertId, Object notification) {
+        String key = "expert_" + expertId;
+        SseEmitter emitter = expertEmitters.get(key);
+
+        if (emitter != null) {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("notification")
+                        .data(notification));
+            } catch (IOException e) {
+                log.error("Failed to send notification to expert {}", expertId, e);
+                expertEmitters.remove(key);
+            }
+        }
+    }
+}

--- a/src/main/java/com/my_medi/api/consultation/service/ConsultationUseCase.java
+++ b/src/main/java/com/my_medi/api/consultation/service/ConsultationUseCase.java
@@ -1,18 +1,23 @@
 package com.my_medi.api.consultation.service;
 
+import com.my_medi.api.common.dto.NotificationEventDto;
 import com.my_medi.api.consultation.dto.ExpertConsultationDto;
 import com.my_medi.api.consultation.dto.ExpertConsultationDto.*;
 import com.my_medi.api.consultation.mapper.ExpertConsultationConverter;
+import com.my_medi.api.expertNotification.mapper.ExpertNotificationConverter;
 import com.my_medi.api.report.dto.HealthStatus;
 import com.my_medi.api.report.dto.UserLatestReportStatusDto;
+import com.my_medi.api.userNotification.mapper.UserNotificationConverter;
 import com.my_medi.common.util.ProposalMapperUtil;
 import com.my_medi.domain.consultationRequest.entity.ConsultationRequest;
 import com.my_medi.domain.consultationRequest.entity.RequestStatus;
 import com.my_medi.domain.consultationRequest.service.ConsultationRequestCommandService;
 import com.my_medi.domain.consultationRequest.service.ConsultationRequestQueryService;
 import com.my_medi.domain.expert.entity.Expert;
+import com.my_medi.domain.notification.entity.ExpertNotification;
 import com.my_medi.domain.notification.entity.NotificationMessage;
 import com.my_medi.domain.notification.entity.NotificationType;
+import com.my_medi.domain.notification.entity.UserNotification;
 import com.my_medi.domain.notification.service.ExpertNotificationCommandService;
 import com.my_medi.domain.proposal.entity.Proposal;
 import com.my_medi.domain.proposal.repository.ProposalRepository;
@@ -21,6 +26,7 @@ import com.my_medi.domain.reportResult.entity.ReportResult;
 import com.my_medi.domain.user.entity.User;
 import com.my_medi.domain.notification.service.UserNotificationCommandService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -42,6 +48,7 @@ public class ConsultationUseCase {
     private final ExpertNotificationCommandService expertNotificationCommandService;
     private final ProposalRepository proposalRepository;
     private final ReportRepository reportRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public void approveConsultationRequestAndSendNotificationToUser(Expert expert, Long consultationId) {
         consultationRequestCommandService.approveConsultation(consultationId, expert);
@@ -50,8 +57,15 @@ public class ConsultationUseCase {
         String notificationComment = NotificationMessage
                 .CONSULTATION_APPROVED.format(expert.getName());
 
-        userNotificationCommandService.sendNotificationToUser(request.getUser().getId(),
+        UserNotification userNotification = userNotificationCommandService.sendNotificationToUser(request.getUser().getId(),
                 consultationId, notificationComment, NotificationType.CONSULTATION_RESPONSE);
+
+        //sse
+        applicationEventPublisher.publishEvent(
+                new NotificationEventDto.UserNotificationEventDto(
+                        UserNotificationConverter.toUserNotification(userNotification)
+                )
+        );
     }
 
     public void rejectConsultationRequestAndSendNotificationToUser(Expert expert, Long consultationId) {
@@ -61,8 +75,18 @@ public class ConsultationUseCase {
         String notificationComment = NotificationMessage
                 .CONSULTATION_REJECTED.format(expert.getName());
 
-        userNotificationCommandService.sendNotificationToUser(request.getUser().getId(),
-                consultationId, notificationComment, NotificationType.CONSULTATION_RESPONSE);
+        UserNotification userNotification = userNotificationCommandService
+                .sendNotificationToUser(
+                        request.getUser().getId(),
+                        consultationId, notificationComment,
+                        NotificationType.CONSULTATION_RESPONSE
+                );
+        //sse
+        applicationEventPublisher.publishEvent(
+                new NotificationEventDto.UserNotificationEventDto(
+                        UserNotificationConverter.toUserNotification(userNotification)
+                )
+        );
     }
 
     //TODO return type 통일하기 Long -> void
@@ -71,8 +95,15 @@ public class ConsultationUseCase {
 
         String notificationComment = NotificationMessage.CONSULTATION_REQUESTED.format(user.getName());
 
-        expertNotificationCommandService.sendNotificationToExpert(expertId, requestId, notificationComment);
+        ExpertNotification expertNotification = expertNotificationCommandService
+                .sendNotificationToExpert(expertId, requestId, notificationComment);
 
+        //sse
+        applicationEventPublisher.publishEvent(
+                new NotificationEventDto.ExpertNotificationEventDto(
+                        ExpertNotificationConverter.toExpertNotification(expertNotification)
+                )
+        );
         return requestId;
     }
 

--- a/src/main/java/com/my_medi/api/consultation/service/ConsultationUseCase.java
+++ b/src/main/java/com/my_medi/api/consultation/service/ConsultationUseCase.java
@@ -8,6 +8,7 @@ import com.my_medi.api.expertNotification.mapper.ExpertNotificationConverter;
 import com.my_medi.api.report.dto.HealthStatus;
 import com.my_medi.api.report.dto.UserLatestReportStatusDto;
 import com.my_medi.api.userNotification.mapper.UserNotificationConverter;
+import com.my_medi.common.annotation.UseCase;
 import com.my_medi.common.util.ProposalMapperUtil;
 import com.my_medi.domain.consultationRequest.entity.ConsultationRequest;
 import com.my_medi.domain.consultationRequest.entity.RequestStatus;
@@ -39,7 +40,7 @@ import java.util.stream.Collectors;
 
 import static com.my_medi.common.consts.StaticVariable.CREATED_DATE;
 
-@Service
+@UseCase
 @RequiredArgsConstructor
 public class ConsultationUseCase {
     private final ConsultationRequestCommandService consultationRequestCommandService;

--- a/src/main/java/com/my_medi/api/consultation/validator/ExpertAllowedToViewUserInfoValidator.java
+++ b/src/main/java/com/my_medi/api/consultation/validator/ExpertAllowedToViewUserInfoValidator.java
@@ -1,5 +1,6 @@
 package com.my_medi.api.consultation.validator;
 
+import com.my_medi.common.annotation.Validator;
 import com.my_medi.domain.consultationRequest.entity.ConsultationRequest;
 import com.my_medi.domain.consultationRequest.entity.RequestStatus;
 import com.my_medi.domain.consultationRequest.exception.ConsultationRequestHandler;
@@ -9,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Component
+@Validator
 @RequiredArgsConstructor
 public class ExpertAllowedToViewUserInfoValidator {
     private final ConsultationRequestRepository consultationRequestRepository;

--- a/src/main/java/com/my_medi/api/expertNotification/controller/ExpertNotificationApiController.java
+++ b/src/main/java/com/my_medi/api/expertNotification/controller/ExpertNotificationApiController.java
@@ -1,17 +1,21 @@
 package com.my_medi.api.expertNotification.controller;
 
+import com.my_medi.api.common.service.SseService;
 import com.my_medi.api.expertNotification.dto.ExpertNotificationResponseDto.ExpertNotificationSimplePageResponse;
 import com.my_medi.api.common.dto.ApiResponseDto;
 import com.my_medi.api.expertNotification.mapper.ExpertNotificationConverter;
 import com.my_medi.api.expertNotification.service.ExpertNotificationUseCase;
 import com.my_medi.common.annotation.AuthExpert;
+import com.my_medi.common.annotation.AuthUser;
 import com.my_medi.domain.expert.entity.Expert;
 import com.my_medi.domain.notification.entity.ExpertNotification;
 import com.my_medi.domain.notification.service.ExpertNotificationCommandService;
+import com.my_medi.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -23,6 +27,7 @@ import java.util.List;
 public class ExpertNotificationApiController {
     private final ExpertNotificationUseCase expertNotificationUseCase;
     private final ExpertNotificationCommandService expertNotificationCommandService;
+    private final SseService sseService;
 
     @Operation(summary = "전문가의 알림을 pagination 으로 조회합니다.")
     @GetMapping
@@ -54,5 +59,12 @@ public class ExpertNotificationApiController {
         expertNotificationCommandService.removeNotifications(notificationId);
 
         return ApiResponseDto.onSuccess(null);
+    }
+
+    @Operation(summary = "사용자 알림 실시간 조회를 위해 sse 연결을 합니다.")
+    @GetMapping("/stream")
+    public ApiResponseDto<String> linkUserAtSse(@AuthUser User user) {
+        sseService.connectUser(user.getId());
+        return ApiResponseDto.onSuccess(HttpStatus.OK.toString());
     }
 }

--- a/src/main/java/com/my_medi/api/expertNotification/service/ExpertNotificationEventListener.java
+++ b/src/main/java/com/my_medi/api/expertNotification/service/ExpertNotificationEventListener.java
@@ -1,18 +1,29 @@
 package com.my_medi.api.expertNotification.service;
 
+import com.my_medi.api.common.dto.NotificationEventDto;
+import com.my_medi.api.common.dto.NotificationEventDto.ExpertNotificationEventDto;
+import com.my_medi.api.common.service.SseService;
 import com.my_medi.api.expertNotification.dto.ExpertNotificationResponseDto;
+import com.my_medi.api.expertNotification.mapper.ExpertNotificationConverter;
+import com.my_medi.domain.notification.entity.ExpertNotification;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 import static com.my_medi.api.expertNotification.dto.ExpertNotificationResponseDto.*;
 
 
-@Service
+@Component
 @RequiredArgsConstructor
 public class ExpertNotificationEventListener {
 
-    public void handleConsultationRequestCreated(ExpertNotificationDto event) {
+    private final SseService sseService;
 
+    public void handleSendingNotificationEvent(ExpertNotificationEventDto expertNotification) {
+        sseService.sendToExpert(
+                expertNotification.getExpertNotificationDto().getExpertId(),
+                expertNotification
+        );
     }
 
 }

--- a/src/main/java/com/my_medi/api/expertNotification/service/ExpertNotificationEventListener.java
+++ b/src/main/java/com/my_medi/api/expertNotification/service/ExpertNotificationEventListener.java
@@ -1,0 +1,18 @@
+package com.my_medi.api.expertNotification.service;
+
+import com.my_medi.api.expertNotification.dto.ExpertNotificationResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.my_medi.api.expertNotification.dto.ExpertNotificationResponseDto.*;
+
+
+@Service
+@RequiredArgsConstructor
+public class ExpertNotificationEventListener {
+
+    public void handleConsultationRequestCreated(ExpertNotificationDto event) {
+
+    }
+
+}

--- a/src/main/java/com/my_medi/api/expertNotification/service/ExpertNotificationUseCase.java
+++ b/src/main/java/com/my_medi/api/expertNotification/service/ExpertNotificationUseCase.java
@@ -1,5 +1,6 @@
 package com.my_medi.api.expertNotification.service;
 
+import com.my_medi.common.annotation.UseCase;
 import com.my_medi.domain.notification.entity.ExpertNotification;
 import com.my_medi.domain.notification.service.ExpertNotificationQueryService;
 import lombok.RequiredArgsConstructor;
@@ -9,7 +10,7 @@ import org.springframework.stereotype.Service;
 import static com.my_medi.common.consts.StaticVariable.PAGINATION_SORTING_BY_ID;
 import static com.my_medi.common.consts.StaticVariable.NOTIFICATION_READ;
 
-@Service
+@UseCase
 @RequiredArgsConstructor
 public class ExpertNotificationUseCase {
     private final ExpertNotificationQueryService expertNotificationQueryService;

--- a/src/main/java/com/my_medi/api/proposal/mapper/ProposalConverter.java
+++ b/src/main/java/com/my_medi/api/proposal/mapper/ProposalConverter.java
@@ -60,7 +60,7 @@ public class ProposalConverter {
     }
 
     // Dto -> Entity
-    public Proposal toEntity(User user, ProposalRequestDto dto) {
+    public static Proposal toEntity(User user, ProposalRequestDto dto) {
         return Proposal.builder()
                 .user(user)
                 .lifeDescription(dto.getLifeDescription())

--- a/src/main/java/com/my_medi/api/proposal/service/GetUserProposalByExpertUseCase.java
+++ b/src/main/java/com/my_medi/api/proposal/service/GetUserProposalByExpertUseCase.java
@@ -3,13 +3,14 @@ package com.my_medi.api.proposal.service;
 import com.my_medi.api.consultation.validator.ExpertAllowedToViewUserInfoValidator;
 import com.my_medi.api.proposal.dto.ProposalResponseDto;
 import com.my_medi.api.proposal.mapper.ProposalConverter;
+import com.my_medi.common.annotation.UseCase;
 import com.my_medi.domain.expert.entity.Expert;
 import com.my_medi.domain.proposal.entity.Proposal;
 import com.my_medi.domain.proposal.service.ProposalQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-@Service
+@UseCase
 @RequiredArgsConstructor
 public class GetUserProposalByExpertUseCase {
     private final ProposalQueryService proposalQueryService;

--- a/src/main/java/com/my_medi/api/report/service/ReportUseCase.java
+++ b/src/main/java/com/my_medi/api/report/service/ReportUseCase.java
@@ -5,6 +5,7 @@ import com.my_medi.api.report.dto.ReportResponseDto.UserReportDto;
 import com.my_medi.api.report.dto.ReportSummaryDto;
 import com.my_medi.api.report.dto.WriteReportRequestDto;
 import com.my_medi.api.report.mapper.ReportConverter;
+import com.my_medi.common.annotation.UseCase;
 import com.my_medi.domain.expert.entity.Expert;
 import com.my_medi.domain.report.entity.Report;
 import com.my_medi.domain.report.exception.ReportHandler;
@@ -22,7 +23,7 @@ import com.my_medi.domain.user.service.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-@Service
+@UseCase
 @RequiredArgsConstructor
 public class ReportUseCase {
     private final ReportQueryService reportQueryService;

--- a/src/main/java/com/my_medi/api/schedule/service/ScheduleUseCase.java
+++ b/src/main/java/com/my_medi/api/schedule/service/ScheduleUseCase.java
@@ -1,12 +1,16 @@
 package com.my_medi.api.schedule.service;
 
+import com.my_medi.api.common.dto.NotificationEventDto;
 import com.my_medi.api.schedule.dto.RegisterScheduleDto;
+import com.my_medi.api.userNotification.mapper.UserNotificationConverter;
 import com.my_medi.domain.expert.entity.Expert;
 import com.my_medi.domain.notification.entity.NotificationMessage;
 import com.my_medi.domain.notification.entity.NotificationType;
+import com.my_medi.domain.notification.entity.UserNotification;
 import com.my_medi.domain.schedule.service.ScheduleCommandService;
 import com.my_medi.domain.notification.service.UserNotificationCommandService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class ScheduleUseCase {
     private final ScheduleCommandService scheduleCommandService;
     private final UserNotificationCommandService userNotificationCommandService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public Long registerScheduleAndSendNotificationToUser(
             Expert expert, Long userId, RegisterScheduleDto registerScheduleDto) {
@@ -22,8 +27,15 @@ public class ScheduleUseCase {
 
         String notificationComment = NotificationMessage.SCHEDULE_REGISTERED.format(expert.getName());
 
-        userNotificationCommandService
+        UserNotification userNotification = userNotificationCommandService
                 .sendNotificationToUser(userId, scheduleId, notificationComment, NotificationType.SCHEDULE);
+
+        //sse
+        applicationEventPublisher.publishEvent(
+                new NotificationEventDto.UserNotificationEventDto(
+                        UserNotificationConverter.toUserNotification(userNotification)
+                )
+        );
 
         return scheduleId;
     }

--- a/src/main/java/com/my_medi/api/schedule/service/ScheduleUseCase.java
+++ b/src/main/java/com/my_medi/api/schedule/service/ScheduleUseCase.java
@@ -3,6 +3,7 @@ package com.my_medi.api.schedule.service;
 import com.my_medi.api.common.dto.NotificationEventDto;
 import com.my_medi.api.schedule.dto.RegisterScheduleDto;
 import com.my_medi.api.userNotification.mapper.UserNotificationConverter;
+import com.my_medi.common.annotation.UseCase;
 import com.my_medi.domain.expert.entity.Expert;
 import com.my_medi.domain.notification.entity.NotificationMessage;
 import com.my_medi.domain.notification.entity.NotificationType;
@@ -13,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
-@Service
+@UseCase
 @RequiredArgsConstructor
 public class ScheduleUseCase {
     private final ScheduleCommandService scheduleCommandService;

--- a/src/main/java/com/my_medi/api/userNotification/controller/UserNotificationApiController.java
+++ b/src/main/java/com/my_medi/api/userNotification/controller/UserNotificationApiController.java
@@ -1,5 +1,6 @@
 package com.my_medi.api.userNotification.controller;
 
+import com.my_medi.api.common.service.SseService;
 import com.my_medi.api.userNotification.dto.UserNotificationResponseDto.UserNotificationSimplePageResponse;
 import com.my_medi.api.userNotification.dto.UserNotificationResponseDto.UserNotificationDto;
 import com.my_medi.api.common.dto.ApiResponseDto;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,6 +26,7 @@ import java.util.List;
 public class UserNotificationApiController {
     private final UserNotificationUseCase userNotificationUseCase;
     private final UserNotificationCommandService userNotificationCommandService;
+    private final SseService sseService;
 
     @Operation(summary = "사용자의 알림을 pagination 으로 조회합니다.")
     @GetMapping
@@ -55,5 +58,12 @@ public class UserNotificationApiController {
         userNotificationCommandService.removeNotifications(notificationId);
 
         return ApiResponseDto.onSuccess(null);
+    }
+
+    @Operation(summary = "사용자 알림 실시간 조회를 위해 sse 연결을 합니다.")
+    @GetMapping("/stream")
+    public ApiResponseDto<String> linkUserAtSse(@AuthUser User user) {
+        sseService.connectUser(user.getId());
+        return ApiResponseDto.onSuccess(HttpStatus.OK.toString());
     }
 }

--- a/src/main/java/com/my_medi/api/userNotification/controller/UserNotificationApiController.java
+++ b/src/main/java/com/my_medi/api/userNotification/controller/UserNotificationApiController.java
@@ -16,7 +16,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
 
@@ -64,9 +66,8 @@ public class UserNotificationApiController {
     }
 
     @Operation(summary = "사용자 알림 실시간 조회를 위해 sse 연결을 합니다.")
-    @GetMapping("/stream")
-    public ApiResponseDto<String> linkUserAtSse(@AuthUser User user) {
-        sseService.connectUser(user.getId());
-        return ApiResponseDto.onSuccess(HttpStatus.OK.toString());
+    @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter linkUserAtSse(@AuthUser User user) {
+        return sseService.connectUser(user.getId());
     }
 }

--- a/src/main/java/com/my_medi/api/userNotification/mapper/UserNotificationConverter.java
+++ b/src/main/java/com/my_medi/api/userNotification/mapper/UserNotificationConverter.java
@@ -8,10 +8,9 @@ import org.springframework.data.domain.Page;
 import java.util.List;
 import java.util.stream.Collectors;
 
-//TODO method 명 통일(to~)
 public class UserNotificationConverter {
 
-    public static UserNotificationDto fromUserNotification(UserNotification userNotification) {
+    public static UserNotificationDto toUserNotification(UserNotification userNotification) {
         return UserNotificationDto.builder()
                 .userNotificationId(userNotification.getId())
                 .userId(userNotification.getUser().getId())
@@ -23,7 +22,7 @@ public class UserNotificationConverter {
 
     public static UserNotificationSimplePageResponse toUserNotificationPageDto(Page<UserNotification> notificationPage) {
         List<UserNotificationDto> content = notificationPage.getContent().stream()
-                .map(UserNotificationConverter::fromUserNotification)
+                .map(UserNotificationConverter::toUserNotification)
                 .collect(Collectors.toList());
 
         return new UserNotificationSimplePageResponse(

--- a/src/main/java/com/my_medi/api/userNotification/service/UserNotificationEventListener.java
+++ b/src/main/java/com/my_medi/api/userNotification/service/UserNotificationEventListener.java
@@ -1,0 +1,29 @@
+package com.my_medi.api.userNotification.service;
+
+import com.my_medi.api.common.service.SseService;
+import com.my_medi.api.userNotification.dto.UserNotificationResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import static com.my_medi.api.userNotification.dto.UserNotificationResponseDto.*;
+
+@Service
+@RequiredArgsConstructor
+public class UserNotificationEventListener {
+
+    private final SseService sseService;
+
+    @Async
+    @EventListener
+    public void handleConsultationApproved(Long userId, UserNotificationDto event){
+        sseService.sendToUser(userId, NotificationCon);
+    }
+
+    @Async
+    @EventListener
+    public void handleScheduleCreated(Long userId, UserNotificationDto event){
+        sseService.sendToUser(userId, event);
+    }
+}

--- a/src/main/java/com/my_medi/api/userNotification/service/UserNotificationEventListener.java
+++ b/src/main/java/com/my_medi/api/userNotification/service/UserNotificationEventListener.java
@@ -1,29 +1,30 @@
 package com.my_medi.api.userNotification.service;
 
+import com.my_medi.api.common.dto.NotificationEventDto;
+import com.my_medi.api.common.dto.NotificationEventDto.UserNotificationEventDto;
 import com.my_medi.api.common.service.SseService;
 import com.my_medi.api.userNotification.dto.UserNotificationResponseDto;
+import com.my_medi.api.userNotification.mapper.UserNotificationConverter;
+import com.my_medi.domain.notification.entity.UserNotification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 import static com.my_medi.api.userNotification.dto.UserNotificationResponseDto.*;
 
-@Service
+@Component
 @RequiredArgsConstructor
 public class UserNotificationEventListener {
 
     private final SseService sseService;
-
     @Async
     @EventListener
-    public void handleConsultationApproved(Long userId, UserNotificationDto event){
-        sseService.sendToUser(userId, NotificationCon);
-    }
-
-    @Async
-    @EventListener
-    public void handleScheduleCreated(Long userId, UserNotificationDto event){
-        sseService.sendToUser(userId, event);
+    public void handleSendingNotificationEvent(UserNotificationEventDto userNotification){
+        sseService.sendToUser(
+                userNotification.getUserNotificationDto().getUserId(),
+                userNotification
+        );
     }
 }

--- a/src/main/java/com/my_medi/api/userNotification/service/UserNotificationUseCase.java
+++ b/src/main/java/com/my_medi/api/userNotification/service/UserNotificationUseCase.java
@@ -1,5 +1,6 @@
 package com.my_medi.api.userNotification.service;
 
+import com.my_medi.common.annotation.UseCase;
 import com.my_medi.domain.notification.entity.UserNotification;
 import com.my_medi.domain.notification.service.UserNotificationQueryService;
 import lombok.RequiredArgsConstructor;
@@ -9,7 +10,7 @@ import org.springframework.stereotype.Service;
 import static com.my_medi.common.consts.StaticVariable.PAGINATION_SORTING_BY_ID;
 import static com.my_medi.common.consts.StaticVariable.NOTIFICATION_READ;
 
-@Service
+@UseCase
 @RequiredArgsConstructor
 public class UserNotificationUseCase {
     private final UserNotificationQueryService userNotificationQueryService;

--- a/src/main/java/com/my_medi/common/annotation/UseCase.java
+++ b/src/main/java/com/my_medi/common/annotation/UseCase.java
@@ -1,6 +1,15 @@
 package com.my_medi.common.annotation;
 
-//TODO @UseCase 생성해서 api package.service에 적용하기
-// 어떻게 커스텀 어노테이션을 생성할 지, 그리고 UseCase와 Service에 차이점이 있을 지 고민해보기
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
 public @interface UseCase {
+    @AliasFor(annotation = Component.class)
+    String value() default "";
 }

--- a/src/main/java/com/my_medi/common/annotation/Validator.java
+++ b/src/main/java/com/my_medi/common/annotation/Validator.java
@@ -1,4 +1,15 @@
 package com.my_medi.common.annotation;
-//TODO UseCase와 동일
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
 public @interface Validator {
+    @AliasFor(annotation = Component.class)
+    String value() default "";
 }

--- a/src/main/java/com/my_medi/common/config/AsyncConfig.java
+++ b/src/main/java/com/my_medi/common/config/AsyncConfig.java
@@ -1,0 +1,8 @@
+package com.my_medi.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig { }

--- a/src/main/java/com/my_medi/common/config/SseEmitterConfig.java
+++ b/src/main/java/com/my_medi/common/config/SseEmitterConfig.java
@@ -1,0 +1,22 @@
+package com.my_medi.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Configuration
+public class SseEmitterConfig {
+
+    @Bean(name = "userEmitters")
+    public Map<String, SseEmitter> userEmitters() {
+        return new ConcurrentHashMap<>();
+    }
+
+    @Bean(name = "expertEmitters")
+    public Map<String, SseEmitter> expertEmitters() {
+        return new ConcurrentHashMap<>();
+    }
+}

--- a/src/main/java/com/my_medi/domain/notification/service/ExpertNotificationCommandService.java
+++ b/src/main/java/com/my_medi/domain/notification/service/ExpertNotificationCommandService.java
@@ -1,9 +1,11 @@
 package com.my_medi.domain.notification.service;
 
+import com.my_medi.domain.notification.entity.ExpertNotification;
+
 import java.util.List;
 
 public interface ExpertNotificationCommandService {
-    void sendNotificationToExpert(Long expertId, Long sourceId, String comment);
+    ExpertNotification sendNotificationToExpert(Long expertId, Long sourceId, String comment);
 
     Long readExpertNotification(Long notificationId);
 

--- a/src/main/java/com/my_medi/domain/notification/service/ExpertNotificationCommandServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/notification/service/ExpertNotificationCommandServiceImpl.java
@@ -22,7 +22,7 @@ public class ExpertNotificationCommandServiceImpl implements ExpertNotificationC
     private final ExpertNotificationRepository expertNotificationRepository;
 
     @Override
-    public void sendNotificationToExpert(Long expertId, Long sourceId, String comment) {
+    public ExpertNotification sendNotificationToExpert(Long expertId, Long sourceId, String comment) {
         Expert expert = expertRepository.findById(expertId)
                 .orElseThrow(() -> ExpertHandler.NOT_FOUND);
 
@@ -33,7 +33,7 @@ public class ExpertNotificationCommandServiceImpl implements ExpertNotificationC
                 .isRead(false)
                 .build();
 
-        expertNotificationRepository.save(expertNotification);
+        return expertNotificationRepository.save(expertNotification);
     }
 
     @Override

--- a/src/main/java/com/my_medi/domain/notification/service/UserNotificationCommandService.java
+++ b/src/main/java/com/my_medi/domain/notification/service/UserNotificationCommandService.java
@@ -1,11 +1,12 @@
 package com.my_medi.domain.notification.service;
 
 import com.my_medi.domain.notification.entity.NotificationType;
+import com.my_medi.domain.notification.entity.UserNotification;
 
 import java.util.List;
 
 public interface UserNotificationCommandService {
-    void sendNotificationToUser(Long userId, Long sourceId, String comment, NotificationType notificationType);
+     UserNotification sendNotificationToUser(Long userId, Long sourceId, String comment, NotificationType notificationType);
 
     Long readUserNotification(Long notificationId);
 

--- a/src/main/java/com/my_medi/domain/notification/service/UserNotificationCommandServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/notification/service/UserNotificationCommandServiceImpl.java
@@ -26,7 +26,7 @@ public class UserNotificationCommandServiceImpl implements UserNotificationComma
     private final UserNotificationRepository userNotificationRepository;
 
     @Override
-    public void sendNotificationToUser(Long userId, Long sourceId, String comment, NotificationType notificationType) {
+    public UserNotification sendNotificationToUser(Long userId, Long sourceId, String comment, NotificationType notificationType) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> UserHandler.NOT_FOUND);
 
@@ -38,7 +38,7 @@ public class UserNotificationCommandServiceImpl implements UserNotificationComma
                 .isRead(false)
                 .build();
 
-        userNotificationRepository.save(userNotification);
+        return userNotificationRepository.save(userNotification);
     }
 
     @Override

--- a/src/main/java/com/my_medi/domain/proposal/service/ProposalCommandServiceImpl.java
+++ b/src/main/java/com/my_medi/domain/proposal/service/ProposalCommandServiceImpl.java
@@ -15,11 +15,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ProposalCommandServiceImpl implements ProposalCommandService {
     private final ProposalRepository proposalRepository;
-    private final ProposalConverter proposalConverter;
 
     @Override
     public Long writeProposal(User user, ProposalRequestDto proposalRequestDto) {
-        Proposal proposal = proposalConverter.toEntity(user, proposalRequestDto);
+        Proposal proposal = ProposalConverter.toEntity(user, proposalRequestDto);
         proposalRepository.save(proposal);
         return proposal.getId();
     }


### PR DESCRIPTION
## #️⃣ 요약 설명

>Notification의 생성(DB 커밋) 과 실시간 전달(SSE 스트림) 을 분리했습니다.
클라이언트는 SSE로 서버와 지속 연결을 유지하고, 서버는 이벤트가 생길 때 일방향으로 푸시합니다.

## 📝 작업 내용

>SSE(Server-Sent Events) 는 HTTP 연결을 유지한 채 서버가 클라이언트로 일방향 이벤트 스트림을 전송하는 방식입니다.

“Notification 데이터의 생성(영속화)”과 “실시간 표시(전달)”는 별개의 관심사이므로 분리 설계했습니다. 생성 사실만 알려주면 되므로 다음과 같이 구성했습니다.

1. SSE 연결(웹: 로그인 시 자동 연결 & 유지. 재연결 시 Last-Event-ID 처리 및 정기 keep-alive 권장)
2. 이벤트 발행: notification 생성 시 ApplicationEventPublisher#publishEvent(new UserNotificationEventDto(...))
3. 이벤트 리스너(비동기, 커밋 후): @TransactionalEventListener(phase = AFTER_COMMIT) (필요 시 @Async) 로 수신
4. SSE 전송: 리스너에서 SseService.sendToUser(...) 또는 sendToExpert(...) 호출

### 왜 비동기/커밋 후인가?

요청 지연 차단: 알림 전송(네트워크 I/O)을 비동기로 분리해 API 응답 지연을 막습니다.

일관성 보장: AFTER_COMMIT에서만 전송해, 롤백된 데이터가 방송되는 문제를 방지합니다.
(단순 실시간성은 유지되며, 트랜잭션 경계에 묶을 필요가 없습니다.)

## 동작 확인

<img width="809" height="439" alt="스크린샷 2025-08-19 오후 9 08 06" src="https://github.com/user-attachments/assets/707aecf5-3daf-4f45-ae84-31610a0aac90" />
## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?