### PR TITLE
fix : access expired time 3m -> 1day for demo day

### DIFF
--- a/src/main/java/com/my_medi/common/consts/StaticVariable.java
+++ b/src/main/java/com/my_medi/common/consts/StaticVariable.java
@@ -17,7 +17,8 @@ public class StaticVariable {
     public static final String PAGINATION_SORTING_BY_ID  = "id";
 
     //JWT
-    public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 3; // 3분
+    //TODO 변경하기 (알림 때문에 데모데이에서 이렇게 사용)
+    public static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24; // 1일
     public static final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 7; // 7일
 
     //HealthReportData JSON 필드 키


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 액세스 토큰 유효기간을 3분에서 1일로 연장했습니다. 이제 사용자는 더 오랜 시간 로그인 상태가 유지되어, 앱을 장시간 사용하거나 일시적으로 벗어났다가 돌아와도 재로그인 빈도가 크게 줄어듭니다. 백그라운드 작업과 장시간 세션이 필요한 기능 이용 시 끊김이 감소합니다. 별도의 설정 변경 없이 자동 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->